### PR TITLE
Change VideoWriter_fourcc to VideoWriter.fourcc to fix unknown reference warning

### DIFF
--- a/memvid/encoder.py
+++ b/memvid/encoder.py
@@ -179,7 +179,7 @@ class MemvidEncoder:
         }
 
         opencv_codec = opencv_codec_map.get(codec, codec)
-        fourcc = cv2.VideoWriter_fourcc(*opencv_codec)
+        fourcc = cv2.VideoWriter.fourcc(*opencv_codec)
 
         return cv2.VideoWriter(
             output_path,


### PR DESCRIPTION
Corrects the `cv2.VideoWriter_fourcc` call to the preferred static method version `cv2.VideoWriter.fourcc` in encoder.py to fix an "unknown reference" code warning.


### ISSUE:
The call to cv2.VideoWriter_fourcc in encoder.py#L177 produces the code warning `"Cannot find reference 'VideoWriter_fourcc' in '__init__.pyi'"`. This is because `VideoWriter_fourcc` is missing in the stubs of cv2, and cv2 no longer maintains its Python stubs (see https://github.com/microsoft/python-type-stubs/issues/353).

![cannot_find_reference_warning_20250624](https://github.com/user-attachments/assets/14c2768e-3990-4b9a-ad52-0f459a5d3900)


### SOLUTION:
The OpenCV team [recommends using the static method `fourcc` on VideoWriter](https://github.com/opencv/opencv/issues/24818#issuecomment-1884574644) to fix the issue.