### PR TITLE
feat: return extra_metadata in search results

### DIFF
--- a/src/memvid/search/api.rs
+++ b/src/memvid/search/api.rs
@@ -346,6 +346,7 @@ impl Memvid {
                 created_at: timestamp_to_rfc3339(frame.timestamp),
                 content_dates: frame.content_dates.clone(),
                 entities: Vec::new(),
+                extra_metadata: frame.extra_metadata.clone(),
                 #[cfg(feature = "temporal_track")]
                 temporal: None,
             };

--- a/src/memvid/search/fallback.rs
+++ b/src/memvid/search/fallback.rs
@@ -134,6 +134,7 @@ pub(super) fn search_with_lex_fallback(
                 created_at: timestamp_to_rfc3339(frame_meta.timestamp),
                 content_dates: frame_meta.content_dates.clone(),
                 entities: Vec::new(),
+                extra_metadata: frame_meta.extra_metadata.clone(),
                 #[cfg(feature = "temporal_track")]
                 temporal: None,
             };
@@ -265,6 +266,7 @@ pub(super) fn search_with_filters_only(
             created_at: timestamp_to_rfc3339(frame.timestamp),
             content_dates: frame.content_dates.clone(),
             entities: Vec::new(),
+            extra_metadata: frame.extra_metadata.clone(),
             #[cfg(feature = "temporal_track")]
             temporal: None,
         };

--- a/src/memvid/search/tantivy.rs
+++ b/src/memvid/search/tantivy.rs
@@ -317,6 +317,7 @@ pub(super) fn try_tantivy_search(
                 created_at: timestamp_to_rfc3339(frame_meta.timestamp),
                 content_dates: frame_meta.content_dates.clone(),
                 entities: Vec::new(),
+                extra_metadata: frame_meta.extra_metadata.clone(),
                 #[cfg(feature = "temporal_track")]
                 temporal: None,
             };

--- a/src/types/search.rs
+++ b/src/types/search.rs
@@ -118,6 +118,9 @@ pub struct SearchHitMetadata {
     /// Entities mentioned in this search hit (from Logic-Mesh).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub entities: Vec<SearchHitEntity>,
+    /// Custom user-defined metadata stored with the frame via PutOptions.extra_metadata.
+    #[serde(default, skip_serializing_if = "std::collections::BTreeMap::is_empty")]
+    pub extra_metadata: std::collections::BTreeMap<String, String>,
     #[cfg(feature = "temporal_track")]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub temporal: Option<SearchHitTemporal>,


### PR DESCRIPTION
## Description
Add [extra_metadata](cci:1://file:///home/pankaj/turbine/accelerated/memvid/src/types/frame.rs:316:0-348:1) field so users can retrieve custom key-value metadata they stored during `put()` operations. This exposes the metadata in search and ask results.

## Related Issue
Fixes #147

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made
- Added `extra_metadata: BTreeMap<String, String>` field to [SearchHitMetadata](cci:2://file:///home/pankaj/turbine/accelerated/memvid/src/types/search.rs:104:0-126:1) in [src/types/search.rs](cci:7://file:///home/pankaj/turbine/accelerated/memvid/src/types/search.rs:0:0-0:0)
- Populated [extra_metadata](cci:1://file:///home/pankaj/turbine/accelerated/memvid/src/types/frame.rs:316:0-348:1) in all search handlers (Fallback, Vector, and Tantivy)

## Testing
- [ ] I have added tests that prove my fix/feature works
- [x] All existing tests pass (`cargo test`)
- [x] I have tested on my local machine

## Documentation
- [ ] I have updated relevant documentation
- [x] I have added doc comments for new public APIs
- [ ] CHANGELOG.md has been updated (if applicable)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings
- [x] I have run `cargo clippy` and addressed any issues
- [x] I have run `cargo fmt` to format my code

## Screenshots (if applicable)
N/A - Backend change only

## Additional Notes
- Backward compatible: Uses `#[serde(default, skip_serializing_if = "BTreeMap::is_empty")]`
- 297 tests pass
- 4 files changed, 7 insertions total