### PR TITLE
chore: update dependencies

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,13 +5,11 @@
 
 # Rust
 target/
-Cargo.lock
 
 # Documentation
 *.md
 docs/
 CHANGELOG.md
-LICENSE
 SECURITY.md
 CODE_OF_CONDUCT.md
 CONTRIBUTING.md

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown: # applies only to version-updates (not security-updates)
+      semver-patch: 7 # wait 7 days before applying patch updates
+      semver-minor: 14
+      semver-major: 28
+    ignore:
+      - dependency-name: "bincode"
+        versions: [ ">=3.0.0" ] # unsupported since v3
+  - package-ecosystem: docker
+    directories:
+      - docker/cli
+      - docker/core
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+  - package-ecosystem: docker-compose
+    directory: docker/core
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown: # https://blog.yossarian.net/2025/11/21/We-should-all-be-using-dependency-cooldowns
+      default-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         rust: [stable]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -28,7 +28,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
 
       - name: Cache cargo
-        uses: actions/cache@v4
+        uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
         with:
           path: |
             ~/.cargo/bin/
@@ -48,7 +48,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -19,16 +19,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -38,7 +38,7 @@ jobs:
         run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: ./docker/cli
           platforms: linux/amd64,linux/arm64

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,14 +19,14 @@ bincode = { version = "2.0.1", features = ["serde"] }
 blake3 = "1.5.1"
 uuid = { version = "1.10.0", features = ["v4", "serde"] }
 log = "0.4.22"
-thiserror = "1.0.63"
+thiserror = "2.0.17"
 fs2 = "0.4.3"
 zstd = "0.13.1"
-lz4_flex = "0.11.5"
+lz4_flex = "0.12.0"
 tracing = "0.1.41"
 serde_json = "1.0.145"
 ed25519-dalek = { version = "2.2.0", features = ["std"] }
-base64 = "0.21.7"
+base64 = "0.22.1"
 sha2 = "0.10.9"
 hex = "0.4.3"
 # extractous uses GraalVM native compilation which doesn't work on Windows ARM or WSL2 on ARM
@@ -36,14 +36,14 @@ regex = "1.11.1"
 time = { version = "0.3.36", features = ["formatting", "parsing"] }
 chrono = { version = "0.4.42", features = ["serde"] }
 interim = { version = "0.2.1", optional = true }
-lopdf = "0.38"
+lopdf = "0.39"
 # Pure Rust PDF text extraction - used as primary extractor when extractous is disabled
 pdf-extract = { version = "0.10", optional = true }
 # High-accuracy PDF text extraction with perfect word spacing (2025)
-pdf_oxide = { version = "0.2", optional = true }
+pdf_oxide = { version = "0.3", optional = true }
 unicode-normalization = "0.1"
 unicode-segmentation = "1.11"
-zip = { version = "0.6", default-features = false, features = ["deflate"] }
+zip = { version = "7.1", default-features = false, features = ["deflate"] }
 quick-xml = "0.31"
 calamine = "0.22"
 pdfium-render = { version = "0.8.28", optional = true }
@@ -53,26 +53,26 @@ crossbeam-channel = { version = "0.5.13", optional = true }
 memmap2 = "0.9"
 memchr = "2.7"
 same-file = "1.0"
-fs-err = "2.11"
-atomic-write-file = "0.2"
+fs-err = "3.2"
+atomic-write-file = "0.3"
 dirs-next = "2.0"
 
-tantivy = { version = "0.24.2", optional = true, default-features = false, features = ["mmap"] }
+tantivy = { version = "0.25.0", optional = true, default-features = false, features = ["mmap"] }
 ort = { version = "2.0.0-rc.10", optional = true }
 hnsw = { version = "0.11.0", optional = true }
 jsonwebtoken = { version = "10.0.0", optional = true, features = ["rust_crypto"] }
 image = { version = "0.25", optional = true, default-features = false, features = ["jpeg", "png", "webp"] }
-ndarray = { version = "0.16", optional = true }
+ndarray = { version = "0.17", optional = true }
 rayon = { version = "1.10", optional = true }
-tokenizers = { version = "0.20", optional = true }
+tokenizers = { version = "0.22", optional = true }
 symphonia = { version = "0.5.3", optional = true, default-features = false, features = ["aac", "mp3", "flac", "isomp4", "ogg", "wav", "pcm"] }
-rubato = { version = "0.15", optional = true }
+rubato = { version = "1.0", optional = true }
 rustfft = { version = "6.2", optional = true }
 
 # Encryption capsules (.mv2e) - feature-gated
 argon2 = { version = "0.5", optional = true }
 aes-gcm = { version = "0.10", optional = true }
-rand = { version = "0.8", optional = true }
+rand = { version = "0.9", optional = true }
 zeroize = { version = "1.7", optional = true }
 
 # Candle ML framework for Whisper transcription

--- a/docker/cli/Dockerfile
+++ b/docker/cli/Dockerfile
@@ -8,12 +8,12 @@ LABEL org.opencontainers.image.source="https://github.com/memvid/memvid"
 LABEL org.opencontainers.image.vendor="Memvid"
 LABEL org.opencontainers.image.version="2.0.131"
 
-# Install system deps + Node.js 22
+# Install system deps + Node.js 24
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     curl \
     libssl3 \
-    && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
     && rm -rf /var/lib/apt/lists/*
 

--- a/docker/core/DOCKER.md
+++ b/docker/core/DOCKER.md
@@ -56,7 +56,7 @@ docker run -it --rm -v $(pwd):/app memvid-dev bash
 ```
 
 **Features:**
-- Rust toolchain 1.85
+- Rust toolchain 1.92
 - All build dependencies
 - Cargo watch (optional)
 - Volume mounting for live development
@@ -72,7 +72,7 @@ docker run --rm memvid-test
 ```
 
 **Features:**
-- Rust toolchain 1.85
+- Rust toolchain 1.92
 - Test dependencies
 - Runs tests automatically
 

--- a/docker/core/Dockerfile
+++ b/docker/core/Dockerfile
@@ -1,6 +1,6 @@
 # Multi-stage Dockerfile for Memvid Core (Rust Library)
 # Build stage
-FROM rust:1.85-slim as builder
+FROM rust:1.92-slim-trixie AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -30,7 +30,7 @@ COPY tests ./tests
 RUN cargo build --release --features lex,pdf_extract
 
 # Runtime stage - minimal image for running examples/tests
-FROM debian:bookworm-slim
+FROM debian:trixie-slim AS runtime
 
 # Install runtime dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -43,7 +43,7 @@ WORKDIR /app
 # Copy the built artifacts from builder
 COPY --from=builder /app/target/release/examples ./examples
 COPY --from=builder /app/target/release/deps ./deps
-COPY --from=builder /app/target/release/libmemvid_core*.rlib ./lib/ 2>/dev/null || true
+COPY --from=builder /app/target/release/libmemvid_core*.rlib ./lib/
 
 # Set environment variables
 ENV RUST_LOG=info

--- a/docker/core/Dockerfile.dev
+++ b/docker/core/Dockerfile.dev
@@ -1,5 +1,5 @@
 # Development Dockerfile for Memvid Core
-FROM rust:1.85-slim
+FROM rust:1.92-slim-trixie AS builder
 
 # Install development dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/docker/core/Dockerfile.test
+++ b/docker/core/Dockerfile.test
@@ -1,5 +1,5 @@
 # Test Dockerfile for Memvid Core
-FROM rust:1.85-slim
+FROM rust:1.92-slim-trixie AS builder
 
 # Install test dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/docker/core/README.md
+++ b/docker/core/README.md
@@ -56,7 +56,7 @@ docker run -it --rm -v $(pwd):/app memvid-dev bash
 ```
 
 **Features:**
-- Rust toolchain 1.85
+- Rust toolchain 1.92
 - All build dependencies
 - Cargo watch (optional)
 - Volume mounting for live development
@@ -72,7 +72,7 @@ docker run --rm memvid-test
 ```
 
 **Features:**
-- Rust toolchain 1.85
+- Rust toolchain 1.92
 - Test dependencies
 - Runs tests automatically
 

--- a/docker/core/docker-compose.yml
+++ b/docker/core/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   # Development environment
   dev:


### PR DESCRIPTION
## Description

### Chores
- Update cargo, docker and github-actions (pin to improve supply chain security)
- Let dependabot update cargo, docker and github-actions
- Bump nodejs 22 to 24, Debian 12 to 13, Rust 1.85 to 1.92 (in Docker)
- Fix Dockerfile and .dockerignore

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)
- [x] Dependency updates

## Testing
- [ ] I have added tests that prove my fix/feature works
- [x] All existing tests pass (`cargo test`)
- [ ] I have tested on my local machine

## Documentation
- [x] I have updated relevant documentation
- [ ] I have added doc comments for new public APIs
- [ ] CHANGELOG.md has been updated (if applicable)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings
- [x] I have run `cargo clippy` and addressed any issues
- [x] I have run `cargo fmt` to format my code

## Additional Notes
### TODO
- Did not update bincode 2 to 3 (it seems the team has been attacked)
- Did not update quick-xml 0.31 to 0.39 (breaking changes)
- Did not update calamine 0.22 to 0.32 (breaking changes)

