### PR TITLE
fix: gate text_embedding example behind vec feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,3 +120,7 @@ symspell_cleanup = ["dep:symspell"]
 [dev-dependencies]
 fastrand = "2.0"
 tempfile = "3.10.1"
+
+[[example]]
+name = "text_embedding"
+required-features = ["vec"]

--- a/examples/text_embedding.rs
+++ b/examples/text_embedding.rs
@@ -1,4 +1,3 @@
-#![cfg(feature = "vec")]
 //! Example demonstrating local text embedding usage.
 //!
 //! This example shows how to:


### PR DESCRIPTION
## Description
Gate `text_embedding` example behind feature to fix CI failure.

## Related Issue
N/A

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made
- Added `required-features = ["vec"]` for `text_embedding` example in `Cargo.toml`

## Testing
- [ ] I have added tests that prove my fix/feature works
- [x] All existing tests pass (`cargo test`)
- [x] I have tested on my local machine

## Documentation
- [ ] I have updated relevant documentation
- [ ] I have added doc comments for new public APIs
- [ ] CHANGELOG.md has been updated (if applicable)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings
- [ ] I have run `cargo clippy` and addressed any issues
- [x] I have run `cargo fmt` to format my code

## Screenshots (if applicable)
N/A

## Additional Notes
The example requires the feature, but was being compiled without it.
