### PR TITLE
feat: add embedding cache with LRU eviction for instant retrieval of …

### DIFF
--- a/examples/text_embed_cache_bench.rs
+++ b/examples/text_embed_cache_bench.rs
@@ -1,0 +1,138 @@
+//! Benchmark demonstrating the performance benefit of embedding caching.
+//!
+//! This example compares performance with and without caching for repeated texts.
+//!
+//! ## Prerequisites
+//!
+//! Download the BGE-small model:
+//!
+//! ```bash
+//! mkdir -p ~/.cache/memvid/text-models
+//! curl -L 'https://huggingface.co/BAAI/bge-small-en-v1.5/resolve/main/onnx/model.onnx' \
+//!   -o ~/.cache/memvid/text-models/bge-small-en-v1.5.onnx
+//! curl -L 'https://huggingface.co/BAAI/bge-small-en-v1.5/resolve/main/tokenizer.json' \
+//!   -o ~/.cache/memvid/text-models/bge-small-en-v1.5_tokenizer.json
+//! ```
+//!
+//! ## Run
+//!
+//! ```bash
+//! cargo run --example text_embed_cache_bench --features vec --release
+//! ```
+
+use memvid_core::Result;
+use memvid_core::text_embed::{LocalTextEmbedder, TextEmbedConfig};
+use std::time::Instant;
+
+fn main() -> Result<()> {
+    println!("╔════════════════════════════════════════════════════════════╗");
+    println!("║  Embedding Cache Benchmark                                ║");
+    println!("╚════════════════════════════════════════════════════════════╝\n");
+
+    // Test texts with intentional repeats
+    let test_texts = vec![
+        "machine learning",
+        "artificial intelligence",
+        "deep learning",
+        "neural networks",
+        "natural language processing",
+        "machine learning",        // Repeat 1
+        "artificial intelligence", // Repeat 2
+        "computer vision",
+        "deep learning",    // Repeat 3
+        "machine learning", // Repeat 4
+    ];
+
+    println!(
+        "Test data: {} texts ({} unique, {} repeats)\n",
+        test_texts.len(),
+        7, // unique
+        3
+    ); // repeats
+
+    // ---------- Test with Cache Enabled ----------
+    println!("──────────────────────────────────────────────────────────");
+    println!("Test 1: WITH Cache (enabled by default)");
+    println!("──────────────────────────────────────────────────────────");
+
+    let config_cached = TextEmbedConfig::default();
+    let embedder_cached = LocalTextEmbedder::new(config_cached)?;
+
+    println!("Processing texts...");
+    let start = Instant::now();
+    for (i, text) in test_texts.iter().enumerate() {
+        let _ = embedder_cached.encode_text(text)?;
+        if i < test_texts.len() - 1 {
+            print!(".");
+        }
+    }
+    println!("!");
+    let cached_time = start.elapsed();
+
+    if let Some(stats) = embedder_cached.cache_stats() {
+        println!("\n📊 Cache Statistics:");
+        println!("   Hits:      {}", stats.hits);
+        println!("   Misses:    {}", stats.misses);
+        println!("   Size:      {}/{}", stats.size, stats.capacity);
+        println!("   Hit Rate:  {:.1}%", stats.hit_rate() * 100.0);
+    }
+
+    println!("\n⏱️  Total Time: {:?}", cached_time);
+
+    // ---------- Test with Cache Disabled ----------
+    println!("\n──────────────────────────────────────────────────────────");
+    println!("Test 2: WITHOUT Cache (force disabled)");
+    println!("──────────────────────────────────────────────────────────");
+
+    let config_uncached = TextEmbedConfig {
+        enable_cache: false,
+        ..Default::default()
+    };
+    let embedder_uncached = LocalTextEmbedder::new(config_uncached)?;
+
+    println!("Processing texts...");
+    let start = Instant::now();
+    for (i, text) in test_texts.iter().enumerate() {
+        let _ = embedder_uncached.encode_text(text)?;
+        if i < test_texts.len() - 1 {
+            print!(".");
+        }
+    }
+    println!("!");
+    let uncached_time = start.elapsed();
+
+    println!("\n⏱️  Total Time: {:?}", uncached_time);
+
+    // ---------- Results ----------
+    println!("\n╔════════════════════════════════════════════════════════════╗");
+    println!("║  Results                                                   ║");
+    println!("╚════════════════════════════════════════════════════════════╝\n");
+
+    let speedup = uncached_time.as_secs_f64() / cached_time.as_secs_f64();
+
+    println!("┌────────────────┬──────────────┬──────────────┐");
+    println!("│ Configuration  │ Time         │ Speedup      │");
+    println!("├────────────────┼──────────────┼──────────────┤");
+    println!(
+        "│ With Cache     │ {:>10.3}s │ {:>9.2}x │",
+        cached_time.as_secs_f64(),
+        speedup
+    );
+    println!(
+        "│ Without Cache  │ {:>10.3}s │     baseline │",
+        uncached_time.as_secs_f64()
+    );
+    println!("└────────────────┴──────────────┴──────────────┘\n");
+
+    if speedup > 1.0 {
+        println!("✅ Cache provides {:.1}% speedup!", (speedup - 1.0) * 100.0);
+    } else {
+        println!("⚠️  No speedup observed (may indicate all cache misses)");
+    }
+
+    println!("\n💡 Note: Speedup increases with more repeated texts.");
+    println!("   Real-world applications with 50-90% repeated queries");
+    println!("   can see 2-10x improvements!\n");
+
+    Ok(())
+}


### PR DESCRIPTION
# Add Embedding Cache with LRU Eviction for Instant Retrieval of Repeated Texts

## Description
Implements an LRU cache for [LocalTextEmbedder](cci:2://file:///home/pankaj/turbine/accelerated/memvid/src/text_embed.rs:326:0-337:1) to avoid recomputing embeddings for repeated texts. The cache provides instant retrieval from memory for previously seen texts, significantly improving performance for applications with repeated queries (search, chatbots, document analysis).

## Related Issue
N/A - Performance enhancement for local text embeddings

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made
- Added [EmbeddingCache](cci:2://file:///home/pankaj/turbine/accelerated/memvid/src/text_embed.rs:241:0-252:1) struct with LRU eviction using HashMap + VecDeque
- Added [CacheStats](cci:2://file:///home/pankaj/turbine/accelerated/memvid/src/text_embed.rs:217:0-226:1) struct for tracking cache hits, misses, and hit rate
- Updated [TextEmbedConfig](cci:2://file:///home/pankaj/turbine/accelerated/memvid/src/text_embed.rs:141:0-152:1) with `enable_cache` (default: true) and `cache_capacity` (default: 1000)
- Modified [LocalTextEmbedder](cci:2://file:///home/pankaj/turbine/accelerated/memvid/src/text_embed.rs:326:0-337:1) to integrate cache with thread-safe Mutex
- Integrated cache lookup and storage into [encode_text](cci:1://file:///home/pankaj/turbine/accelerated/memvid/src/text_embed.rs:506:4-694:5) method
- Added [cache_stats()](cci:1://file:///home/pankaj/turbine/accelerated/memvid/src/text_embed.rs:705:4-714:5) and [clear_cache()](cci:1://file:///home/pankaj/turbine/accelerated/memvid/src/text_embed.rs:716:4-727:5) utility methods
- Added 9 comprehensive unit tests for cache functionality
- Created [text_embed_cache_bench.rs](cci:7://file:///home/pankaj/turbine/accelerated/memvid/examples/text_embed_cache_bench.rs:0:0-0:0) example to demonstrate speedup

## Testing
- [x] I have added tests that prove my fix/feature works
- [x] All existing tests pass (`cargo test`)
- [x] I have tested on my local machine

**Test results:**
<img width="1091" height="368" alt="Screenshot from 2026-01-15 03-53-44" src="https://github.com/user-attachments/assets/d54a7bde-e650-410f-a729-ebc52977b2b4" />


## Documentation
- [x] I have updated relevant documentation
- [x] I have added doc comments for new public APIs
- [ ] CHANGELOG.md has been updated (if applicable)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings
- [ ] I have run `cargo clippy` and addressed any issues
- [x] I have run `cargo fmt` to format my code

## Performance Impact

**Memory usage:**
- Default cache (1000 items): ~1.5MB
- Configurable via `cache_capacity` in config

**Speed improvements:**
- Cache hit: ~0.001ms (instant retrieval)
- Cache miss: Normal speed (~100ms)
- Real-world scenario (50% repeats): **2x faster**
- Real-world scenario (90% repeats): **10x faster**

## Benchmark Results
Run this command to see cache performance (requires model download):
```bash
cargo run --example text_embed_cache_bench --features vec --release
```

## Screenshots (if applicable)
<img width="1302" height="1036" alt="Screenshot from 2026-01-15 03-56-12" src="https://github.com/user-attachments/assets/3298c1e6-3064-4549-ba9e-1c8bf0df162d" />
