### PR TITLE
fix: downgrade ndarray to 0.16 for ort compatibility and add missing …

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ ort = { version = "2.0.0-rc.10", optional = true }
 hnsw = { version = "0.11.0", optional = true }
 jsonwebtoken = { version = "10.0.0", optional = true, features = ["rust_crypto"] }
 image = { version = "0.25", optional = true, default-features = false, features = ["jpeg", "png", "webp"] }
-ndarray = { version = "0.17", optional = true }
+ndarray = { version = "0.16", optional = true }
 rayon = { version = "1.10", optional = true }
 tokenizers = { version = "0.22", optional = true }
 symphonia = { version = "0.5.3", optional = true, default-features = false, features = ["aac", "mp3", "flac", "isomp4", "ogg", "wav", "pcm"] }
@@ -123,4 +123,8 @@ tempfile = "3.10.1"
 
 [[example]]
 name = "text_embedding"
+required-features = ["vec"]
+
+[[example]]
+name = "text_embed_cache_bench"
 required-features = ["vec"]


### PR DESCRIPTION
## Description

Fixes ndarray version incompatibility that prevented [vec](cci:1://file:///home/pankaj/turbine/accelerated/memvid/src/lib.rs:634:4-667:5), `logic_mesh`, and [clip](cci:1://file:///home/pankaj/turbine/accelerated/memvid/src/clip.rs:65:0-69:1) features from compiling.

**Changes:**
- Downgrade ndarray from 0.17 → 0.16 (matches ort requirements)
- Add missing `required-features` for `text_embed_cache_bench` example
- Fix tensor creation in [text_embed.rs](cci:7://file:///home/pankaj/turbine/accelerated/memvid/src/text_embed.rs:0:0-0:0)

**Root Cause:** ndarray 0.17 changed type signatures (2-param → 3-param), breaking ort's trait bounds.

## Type of Change
- [x] Bug fix

## Changes Made
- [Cargo.toml](cci:7://file:///home/pankaj/turbine/accelerated/memvid/Cargo.toml:0:0-0:0): ndarray 0.17 → 0.16 + example config
- [src/text_embed.rs](cci:7://file:///home/pankaj/turbine/accelerated/memvid/src/text_embed.rs:0:0-0:0): Fixed tensor creation + removed unused import

## Testing
- [x] cargo check --features vec  
- [x] cargo check --features logic_mesh  
- [x] cargo check --example text_embed_cache_bench --features vec

## Screenshots

<img width="1380" height="373" alt="Screenshot from 2026-01-16 01-21-20" src="https://github.com/user-attachments/assets/4bc2e2be-35a8-49fe-bf23-4ee7e24847e6" />


## Additional Notes
- Minimal changes: 2 files, +17/-17 lines
- Backward compatible downgrade
- Completes embedding cache feature from PR #157