### PR TITLE
feat: add Whisper model quantization support and fix rubato 1.0 compa…

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,44 @@ cargo run --example clip_visual_search --features clip
 Audio transcription (requires `whisper` feature):
 
 ```bash
-cargo run --example test_whisper --features whisper
+cargo run --example test_whisper --features whisper -- /path/to/audio.mp3
+```
+
+**Available Models:**
+
+| Model | Size | Speed | Use Case |
+|-------|------|-------|----------|
+| `whisper-small-en` | 244 MB | Slowest | Best accuracy (default) |
+| `whisper-tiny-en` | 75 MB | Fast | Balanced |
+| `whisper-tiny-en-q8k` | 19 MB | Fastest | Quick testing, resource-constrained |
+
+**Model Selection:**
+
+```bash
+# Default (FP32 small, highest accuracy)
+cargo run --example test_whisper --features whisper -- audio.mp3
+
+# Quantized tiny (75% smaller, faster)
+MEMVID_WHISPER_MODEL=whisper-tiny-en-q8k cargo run --example test_whisper --features whisper -- audio.mp3
+```
+
+**Programmatic Configuration:**
+
+```rust
+use memvid_core::{WhisperConfig, WhisperTranscriber};
+
+// Default FP32 small model
+let config = WhisperConfig::default();
+
+// Quantized tiny model (faster, smaller)
+let config = WhisperConfig::with_quantization();
+
+// Specific model
+let config = WhisperConfig::with_model("whisper-tiny-en-q8k");
+
+let transcriber = WhisperTranscriber::new(&config)?;
+let result = transcriber.transcribe_file("audio.mp3")?;
+println!("{}", result.text);
 ```
 
 ---


### PR DESCRIPTION
…tibility

## Description
Add Whisper model quantization support (Q8K/Q4K) as it Unimplementated and fix rubato 1.0 API compatibility. Users can now choose between FP32 and quantized models for faster, smaller downloads while maintaining backward compatibility.

## Related Issue
N/A (Feature enhancement)

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [x] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made
- Added `QuantizationType` enum (FP32, Q8K, Q4K) for model selection
- Updated [WhisperModelInfo](cci:2://file:///home/pankaj/turbine/accelerated/memvid/src/whisper.rs:42:0-57:1) struct with [quantization](cci:1://file:///home/pankaj/turbine/accelerated/memvid/src/whisper.rs:170:4-180:5) and `file_format` fields
- Added quantized model variants: `whisper-tiny-en-q8k`, `whisper-tiny-q8k`
- Implemented conditional model loading: safetensors for FP32, GGUF for quantized
- Added config helpers: [with_quantization()](cci:1://file:///home/pankaj/turbine/accelerated/memvid/src/whisper.rs:170:4-180:5), [tiny()](cci:1://file:///home/pankaj/turbine/accelerated/memvid/src/whisper.rs:200:4-207:5), [multilingual_quantized()](cci:1://file:///home/pankaj/turbine/accelerated/memvid/src/whisper.rs:191:4-198:5)
- Fixed rubato 1.0 API breaking change (FftFixedIn removed in 1.0)
- Updated README with model selection documentation

## Testing
- [x] I have added tests that prove my fix/feature works
- [x] All existing tests pass (`cargo test`)
- [x] I have tested on my local machine

## Documentation
- [x] I have updated relevant documentation
- [ ] I have added doc comments for new public APIs
- [ ] CHANGELOG.md has been updated (if applicable)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings
- [ ] I have run `cargo clippy` and addressed any issues
- [x] I have run `cargo fmt` to format my code

## Screenshots (if applicable)
**quantized** 
<img width="1909" height="589" alt="Screenshot from 2026-01-16 23-56-10" src="https://github.com/user-attachments/assets/9123b961-c2b9-477c-a692-6e2f8700fa0f" />

**Orignal**
<img width="1909" height="589" alt="Screenshot from 2026-01-16 23-58-20" src="https://github.com/user-attachments/assets/e171510d-2828-437f-928d-edcb92d7169b" />


## Additional Notes
**Backward Compatibility:** Fully backward compatible. Default behavior unchanged (`whisper-small-en` FP32).