### PR TITLE
feat: enforce vector index model consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,18 @@ let embedder = LocalTextEmbedder::new(config)?;
 
 See `examples/text_embedding.rs` for a complete example with similarity computation and search ranking.
 
+### Model Consistency
+
+To prevent accidental model mixing (e.g., querying a BGE-small index with OpenAI embeddings), you can explicitly bind your Memvid instance to a specific model name:
+
+```rust
+// Bind the index to a specific model.
+// If the index was previously created with a different model, this will return an error.
+mem.set_vec_model("bge-small-en-v1.5")?;
+```
+
+This binding is persistent. Once set, future attempts to use a different model name will fail fast with a `ModelMismatch` error.
+
 ---
 
 ## API Embeddings (OpenAI)

--- a/src/error.rs
+++ b/src/error.rs
@@ -205,6 +205,9 @@ pub enum MemvidError {
     #[error("Reranking failed: {reason}")]
     RerankFailed { reason: Box<str> },
 
+    #[error("Model mismatch: Index is bound to '{expected}', but requested model was '{actual}'")]
+    ModelMismatch { expected: String, actual: String },
+
     #[error("Invalid query: {reason}")]
     InvalidQuery { reason: String },
 

--- a/src/memvid/enrichment.rs
+++ b/src/memvid/enrichment.rs
@@ -510,6 +510,7 @@ impl Memvid {
             bytes_length: artifact.bytes.len() as u64,
             checksum: artifact.checksum,
             compression_mode: crate::types::VectorCompression::None,
+            model: self.vec_model.clone(),
         });
 
         self.dirty = true;

--- a/src/memvid/lifecycle.rs
+++ b/src/memvid/lifecycle.rs
@@ -67,6 +67,7 @@ pub struct Memvid {
     pub(crate) lex_storage: Arc<RwLock<EmbeddedLexStorage>>,
     pub(crate) vec_enabled: bool,
     pub(crate) vec_compression: VectorCompression,
+    pub(crate) vec_model: Option<String>,
     pub(crate) vec_index: Option<VecIndex>,
     /// CLIP visual embeddings index (separate from vec due to different dimensions)
     pub(crate) clip_enabled: bool,
@@ -187,6 +188,7 @@ impl Memvid {
             lex_storage,
             vec_enabled: cfg!(feature = "vec"), // Enable by default if feature is enabled
             vec_compression: VectorCompression::None,
+            vec_model: None,
             vec_index: None,
             clip_enabled: cfg!(feature = "clip"), // Enable by default if feature is enabled
             clip_index: None,
@@ -365,6 +367,7 @@ impl Memvid {
             lex_storage,
             vec_enabled: false,
             vec_compression: VectorCompression::None,
+            vec_model: None,
             vec_index: None,
             clip_enabled: false,
             clip_index: None,
@@ -493,6 +496,7 @@ impl Memvid {
             lex_storage,
             vec_enabled: false,
             vec_compression: VectorCompression::None,
+            vec_model: None,
             vec_index: None,
             clip_enabled: false,
             clip_index: None,

--- a/src/memvid/mutation.rs
+++ b/src/memvid/mutation.rs
@@ -1793,6 +1793,7 @@ impl Memvid {
                 bytes_length: 0,
                 checksum: empty_checksum,
                 compression_mode: self.vec_compression.clone(),
+                model: self.vec_model.clone(),
             });
         }
         if let Some(manifest) = self.toc.indexes.vec.as_mut() {
@@ -2047,6 +2048,7 @@ impl Memvid {
                 bytes_length: artifact.bytes.len() as u64,
                 checksum: artifact.checksum,
                 compression_mode: self.vec_compression.clone(),
+                model: self.vec_model.clone(),
             });
             self.vec_index = Some(index);
         } else {

--- a/src/memvid/search/builders.rs
+++ b/src/memvid/search/builders.rs
@@ -123,6 +123,9 @@ impl Memvid {
     }
 
     pub(crate) fn load_vec_index_from_manifest(&mut self) -> Result<()> {
+        // Load the model name from the manifest regardless of validation success
+        self.vec_model = self.toc.indexes.vec.as_ref().and_then(|m| m.model.clone());
+
         if let Some(manifest) = &self.toc.indexes.vec {
             // Empty manifest (placeholder for enabled but not yet populated index)
             if manifest.bytes_length == 0 {

--- a/src/types/manifest.rs
+++ b/src/types/manifest.rs
@@ -717,6 +717,10 @@ pub struct VecIndexManifest {
     /// Compression mode for vector storage (default: None for backward compatibility)
     #[serde(default)]
     pub compression_mode: VectorCompression,
+    /// Model used to generate embeddings (e.g., "openai-text-embedding-3-small").
+    /// Added in v2 to prevent model mismatch.
+    #[serde(default)]
+    pub model: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]

--- a/tests/model_consistency.rs
+++ b/tests/model_consistency.rs
@@ -1,0 +1,79 @@
+use memvid_core::{Memvid, MemvidError};
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
+
+type TestResult = Result<(), Box<dyn std::error::Error>>;
+
+fn create_tmp_memvid() -> Result<(TempDir, PathBuf), Box<dyn std::error::Error>> {
+    let dir = TempDir::new()?;
+    let path = dir.path().join("test.mv2");
+    // Create new memory
+    {
+        let mut mem = Memvid::create(&path)?;
+        mem.commit()?;
+    }
+    Ok((dir, path))
+}
+
+fn open_tmp_memvid(path: &Path) -> Result<Memvid, Box<dyn std::error::Error>> {
+    Ok(Memvid::open(path)?)
+}
+
+#[test]
+fn test_vec_model_consistency() -> TestResult {
+    let (_dir, path) = create_tmp_memvid()?;
+
+    // 1. Create index and set model "A"
+    {
+        let mut memvid = open_tmp_memvid(&path)?;
+        memvid.enable_vec()?;
+        memvid.set_vec_model("model-a")?;
+        memvid.commit()?;
+    }
+
+    // 2. Open and verify "model-a" matches and "model-b" fails
+    {
+        let mut memvid = open_tmp_memvid(&path)?;
+        // Should succeed (idempotent)
+        memvid.set_vec_model("model-a")?;
+
+        // Should fail
+        let result = memvid.set_vec_model("model-b");
+        assert!(result.is_err());
+        match result {
+            Err(MemvidError::ModelMismatch { expected, actual }) => {
+                assert_eq!(expected, "model-a");
+                assert_eq!(actual, "model-b");
+            }
+            _ => panic!("Expected ModelMismatch error"),
+        }
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_vec_model_persistence() -> TestResult {
+    let (_dir, path) = create_tmp_memvid()?;
+
+    // 1. Create index with model
+    {
+        let mut memvid = open_tmp_memvid(&path)?;
+        memvid.enable_vec()?;
+        memvid.set_vec_model("persistent-model")?;
+        memvid.commit()?;
+    }
+
+    // 2. Open and check if model is loaded automatically
+    {
+        let mut memvid = open_tmp_memvid(&path)?;
+        // We can inspect internal state via debug or by trying to set a mismatch
+        let result = memvid.set_vec_model("wrong-model");
+        assert!(result.is_err());
+
+        // Verify set_vec_model("persistent-model") works (confirming loaded state)
+        memvid.set_vec_model("persistent-model")?;
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Description
This PR implements strict model binding for vector indices to ensure consistency and prevent silent data corruption. Previously, it was possible to create an index with one embedding model (e.g., `openai`) and query it with another (e.g., `bge-small`), leading to meaningless results.

This change adds a [model](cci:1://file:///home/pankaj/turbine/accelerated/memvid-workspace/memvid/src/memvid/search/api.rs:97:4-119:5) field to the vector index manifest. When an index is created or used, it is now bound to a specific model name. Any subsequent attempt to use that index with a different model will fail fast with a clear `ModelMismatch` error.

## Related Issue
Fixes # (N/A - Feature Implementation)

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change) - *Enforces validation that may reject previously allowed mismatched configurations*
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made
- **Manifest**: Added optional [model](cci:1://file:///home/pankaj/turbine/accelerated/memvid-workspace/memvid/src/memvid/search/api.rs:97:4-119:5) field to [VecIndexManifest](cci:2://file:///home/pankaj/turbine/accelerated/memvid-workspace/memvid/src/types/manifest.rs:710:0-723:1) (backward compatible).
- **Core Logic**: Updated [Memvid](cci:2://file:///home/pankaj/turbine/accelerated/memvid-workspace/memvid/src/memvid/lifecycle.rs:47:0-99:1) lifecycle to persist and load the model name from the Table of Contents.
- **API**: Added [set_vec_model(model: &str)](cci:1://file:///home/pankaj/turbine/accelerated/memvid-workspace/memvid/src/memvid/search/api.rs:97:4-119:5) to explicitly bind the index and validate consistency.
- **Error Handling**: Introduced `MemvidError::ModelMismatch` for clear feedback when model names conflict.
- **Safety**: Updated [enable_vec](cci:1://file:///home/pankaj/turbine/accelerated/memvid-workspace/memvid/src/memvid/search/api.rs:67:4-95:5) and enrichment workflows to propagate the bound model name.

## Testing
- [x] I have added tests that prove my fix/feature works
    - Added [tests/model_consistency.rs](cci:7://file:///home/pankaj/turbine/accelerated/memvid-workspace/memvid/tests/model_consistency.rs:0:0-0:0) covering:
        - Successful binding.
        - Failure on mismatch (`ModelMismatch`).
        - Persistence across commit/reload cycles.
- [x] All existing tests pass (`cargo test`)
- [x] I have tested on my local machine

## Documentation
- [x] I have updated relevant documentation ([README.md](cci:7://file:///home/pankaj/turbine/accelerated/memvid-workspace/memvid/README.md:0:0-0:0) updated with [set_vec_model](cci:1://file:///home/pankaj/turbine/accelerated/memvid-workspace/memvid/src/memvid/search/api.rs:97:4-119:5) examples)
- [x] I have added doc comments for new public APIs
- [ ] CHANGELOG.md has been updated (if applicable)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings
- [x] I have run `cargo clippy` and addressed any issues
- [x] I have run `cargo fmt` to format my code

## Screenshots (if applicable)
N/A - Library logic change.

## Additional Notes
The [model](cci:1://file:///home/pankaj/turbine/accelerated/memvid-workspace/memvid/src/memvid/search/api.rs:97:4-119:5) field in [VecIndexManifest](cci:2://file:///home/pankaj/turbine/accelerated/memvid-workspace/memvid/src/types/manifest.rs:710:0-723:1) is marked with `#[serde(default)]`, so existing `.mv2` files will continue to load without issues (effectively "unbound" until `set_vec_model` is called).
