### PR TITLE
add offline ndcg eval harness (pr1)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -154,6 +154,10 @@ required-features = ["api_embed"]
 name = "simd_benchmark"
 required-features = ["simd"]
 
+[[test]]
+name = "evals"
+required-features = ["evals", "lex"]
+
 [[bench]]
 name = "search_precision_benchmark"
 harness = false

--- a/data/eval_fixtures.json
+++ b/data/eval_fixtures.json
@@ -1,0 +1,229 @@
+[
+  {
+    "query": "write ahead log crash recovery",
+    "relevant_uris": [
+      "mv2://docs/wal.md",
+      "mv2://docs/crash-safety.md"
+    ],
+    "grades": [1.0, 0.5]
+  },
+  {
+    "query": "how does the WAL checkpoint trigger",
+    "relevant_uris": [
+      "mv2://docs/wal.md"
+    ],
+    "grades": [1.0]
+  },
+  {
+    "query": "single file format mv2 structure",
+    "relevant_uris": [
+      "mv2://docs/file-format.md",
+      "mv2://docs/header.md"
+    ],
+    "grades": [1.0, 0.5]
+  },
+  {
+    "query": "header size bytes offset",
+    "relevant_uris": [
+      "mv2://docs/header.md"
+    ],
+    "grades": [1.0]
+  },
+  {
+    "query": "BM25 full text search tantivy",
+    "relevant_uris": [
+      "mv2://docs/lex-index.md",
+      "mv2://docs/search.md"
+    ],
+    "grades": [1.0, 0.5]
+  },
+  {
+    "query": "lexical search index fields uri title content",
+    "relevant_uris": [
+      "mv2://docs/lex-index.md"
+    ],
+    "grades": [1.0]
+  },
+  {
+    "query": "HNSW vector similarity search approximate nearest neighbour",
+    "relevant_uris": [
+      "mv2://docs/vec-index.md",
+      "mv2://docs/search.md"
+    ],
+    "grades": [1.0, 0.5]
+  },
+  {
+    "query": "vector index flat scan threshold",
+    "relevant_uris": [
+      "mv2://docs/vec-index.md"
+    ],
+    "grades": [1.0]
+  },
+  {
+    "query": "hybrid search reciprocal rank fusion RRF",
+    "relevant_uris": [
+      "mv2://docs/search.md",
+      "mv2://docs/ask.md"
+    ],
+    "grades": [1.0, 0.5]
+  },
+  {
+    "query": "sketch simhash pre filter candidate generation",
+    "relevant_uris": [
+      "mv2://docs/sketch.md"
+    ],
+    "grades": [1.0]
+  },
+  {
+    "query": "SimHash locality sensitive hashing",
+    "relevant_uris": [
+      "mv2://docs/sketch.md",
+      "mv2://docs/search.md"
+    ],
+    "grades": [1.0, 0.5]
+  },
+  {
+    "query": "frame immutable append only design",
+    "relevant_uris": [
+      "mv2://docs/frame.md",
+      "mv2://docs/file-format.md"
+    ],
+    "grades": [1.0, 0.5]
+  },
+  {
+    "query": "put bytes commit write operation",
+    "relevant_uris": [
+      "mv2://docs/mutation.md",
+      "mv2://docs/wal.md"
+    ],
+    "grades": [1.0, 0.5]
+  },
+  {
+    "query": "PutOptions builder uri title tags",
+    "relevant_uris": [
+      "mv2://docs/mutation.md"
+    ],
+    "grades": [1.0]
+  },
+  {
+    "query": "CLIP image embedding visual search",
+    "relevant_uris": [
+      "mv2://docs/clip.md"
+    ],
+    "grades": [1.0]
+  },
+  {
+    "query": "Whisper audio transcription feature flag",
+    "relevant_uris": [
+      "mv2://docs/whisper.md"
+    ],
+    "grades": [1.0]
+  },
+  {
+    "query": "AES-256-GCM encryption capsule mv2e",
+    "relevant_uris": [
+      "mv2://docs/encryption.md"
+    ],
+    "grades": [1.0]
+  },
+  {
+    "query": "timeline chronological index query",
+    "relevant_uris": [
+      "mv2://docs/timeline.md",
+      "mv2://docs/file-format.md"
+    ],
+    "grades": [1.0, 0.5]
+  },
+  {
+    "query": "time travel replay as_of_frame as_of_ts",
+    "relevant_uris": [
+      "mv2://docs/replay.md",
+      "mv2://docs/timeline.md"
+    ],
+    "grades": [1.0, 0.5]
+  },
+  {
+    "query": "logic mesh entity relationship NER",
+    "relevant_uris": [
+      "mv2://docs/mesh.md"
+    ],
+    "grades": [1.0]
+  },
+  {
+    "query": "ACL access control caller identity enforcement",
+    "relevant_uris": [
+      "mv2://docs/acl.md"
+    ],
+    "grades": [1.0]
+  },
+  {
+    "query": "verify file integrity deep check",
+    "relevant_uris": [
+      "mv2://docs/verify.md",
+      "mv2://docs/doctor.md"
+    ],
+    "grades": [1.0, 0.5]
+  },
+  {
+    "query": "Blake3 hash checksum deterministic",
+    "relevant_uris": [
+      "mv2://docs/checksums.md",
+      "mv2://docs/frame.md"
+    ],
+    "grades": [1.0, 0.5]
+  },
+  {
+    "query": "zstd lz4 compression frame bytes",
+    "relevant_uris": [
+      "mv2://docs/compression.md",
+      "mv2://docs/frame.md"
+    ],
+    "grades": [1.0, 0.5]
+  },
+  {
+    "query": "feature flag conditional compilation cfg",
+    "relevant_uris": [
+      "mv2://docs/features.md"
+    ],
+    "grades": [1.0]
+  },
+  {
+    "query": "search cursor pagination next page",
+    "relevant_uris": [
+      "mv2://docs/search.md"
+    ],
+    "grades": [1.0]
+  },
+  {
+    "query": "adaptive retrieval relevance score distribution",
+    "relevant_uris": [
+      "mv2://docs/ask.md",
+      "mv2://docs/search.md"
+    ],
+    "grades": [1.0, 0.5]
+  },
+  {
+    "query": "ask RAG retrieval augmented generation context fragments",
+    "relevant_uris": [
+      "mv2://docs/ask.md"
+    ],
+    "grades": [1.0]
+  },
+  {
+    "query": "TOC table of contents footer file format",
+    "relevant_uris": [
+      "mv2://docs/file-format.md",
+      "mv2://docs/header.md"
+    ],
+    "grades": [1.0, 0.5]
+  },
+  {
+    "query": "open create memvid file lock crash safe",
+    "relevant_uris": [
+      "mv2://docs/lifecycle.md",
+      "mv2://docs/wal.md",
+      "mv2://docs/crash-safety.md"
+    ],
+    "grades": [1.0, 0.5, 0.5]
+  }
+]

--- a/src/evals/ground_truth.rs
+++ b/src/evals/ground_truth.rs
@@ -1,0 +1,157 @@
+//! ground truth fixture loader.
+//!
+//! each eval case pairs a query with expected uris and graded relevance
+//! (1.0 = perfect, 0.5 = partial, 0.0 = irrelevant).
+//!
+//! fixtures use uris instead of frame ids so they're portable across
+//! different .mv2 files. embedded via include_str! — no runtime io.
+
+use serde::{Deserialize, Serialize};
+
+use crate::{MemvidError, Result};
+
+const EMBEDDED_FIXTURE: &str = include_str!("../../data/eval_fixtures.json");
+
+/// a single ground truth case: query + expected uris + relevance grades
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EvalCase {
+    pub query: String,
+    pub relevant_uris: Vec<String>,
+    pub grades: Vec<f32>,
+}
+
+impl EvalCase {
+    fn validate(&self) -> Result<()> {
+        if self.query.trim().is_empty() {
+            return Err(MemvidError::SchemaValidation {
+                reason: "EvalCase query must not be empty".into(),
+            });
+        }
+        if self.relevant_uris.len() != self.grades.len() {
+            return Err(MemvidError::SchemaValidation {
+                reason: format!(
+                    "EvalCase '{}': relevant_uris ({}) and grades ({}) must have equal length",
+                    self.query,
+                    self.relevant_uris.len(),
+                    self.grades.len()
+                ),
+            });
+        }
+        for &g in &self.grades {
+            if !(0.0..=1.0).contains(&g) {
+                return Err(MemvidError::SchemaValidation {
+                    reason: format!(
+                        "EvalCase '{}': grade {g} out of range [0.0, 1.0]",
+                        self.query
+                    ),
+                });
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct EvalSuite {
+    pub cases: Vec<EvalCase>,
+}
+
+impl EvalSuite {
+    /// load the bundled fixture from data/eval_fixtures.json
+    pub fn from_embedded() -> Result<Self> {
+        Self::from_json(EMBEDDED_FIXTURE)
+    }
+
+    /// parse a custom fixture from a json string
+    pub fn from_json(json: &str) -> Result<Self> {
+        let cases: Vec<EvalCase> = serde_json::from_str(json)
+            .map_err(|e| MemvidError::SchemaValidation {
+                reason: format!("failed to parse eval fixtures: {e}"),
+            })?;
+
+        for case in &cases {
+            case.validate()?;
+        }
+
+        Ok(Self { cases })
+    }
+
+    /// load from a file on disk (handy during dev without recompiling)
+    pub fn from_file(path: &std::path::Path) -> Result<Self> {
+        let json = std::fs::read_to_string(path)
+            .map_err(|e| MemvidError::Io { source: e, path: Some(path.to_path_buf()) })?;
+        Self::from_json(&json)
+    }
+
+    /// Number of cases in the suite.
+    pub fn len(&self) -> usize {
+        self.cases.len()
+    }
+
+    /// Whether the suite is empty.
+    pub fn is_empty(&self) -> bool {
+        self.cases.is_empty()
+    }
+
+    /// keep only cases whose query contains keyword (case-insensitive)
+    pub fn filter_by_keyword(&self, keyword: &str) -> Self {
+        let lower = keyword.to_lowercase();
+        Self {
+            cases: self
+                .cases
+                .iter()
+                .filter(|c| c.query.to_lowercase().contains(&lower))
+                .cloned()
+                .collect(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn embedded_fixture_parses_and_validates() {
+        let suite = EvalSuite::from_embedded().expect("embedded fixture must be valid");
+        assert!(
+            !suite.is_empty(),
+            "embedded fixture must contain at least one case"
+        );
+        for case in &suite.cases {
+            assert!(!case.query.is_empty());
+            assert_eq!(case.relevant_uris.len(), case.grades.len());
+        }
+    }
+
+    #[test]
+    fn from_json_rejects_mismatched_lengths() {
+        let json = r#"[{"query":"test","relevant_uris":["a","b"],"grades":[1.0]}]"#;
+        assert!(EvalSuite::from_json(json).is_err());
+    }
+
+    #[test]
+    fn from_json_rejects_grade_out_of_range() {
+        let json = r#"[{"query":"test","relevant_uris":["a"],"grades":[1.5]}]"#;
+        assert!(EvalSuite::from_json(json).is_err());
+    }
+
+    #[test]
+    fn from_json_rejects_empty_query() {
+        let json = r#"[{"query":"  ","relevant_uris":["a"],"grades":[1.0]}]"#;
+        assert!(EvalSuite::from_json(json).is_err());
+    }
+
+    #[test]
+    fn filter_by_keyword_works() {
+        let suite = EvalSuite::from_embedded().unwrap();
+        let filtered = suite.filter_by_keyword("crash");
+        for case in &filtered.cases {
+            assert!(
+                case.query.to_lowercase().contains("crash"),
+                "unexpected case: {}",
+                case.query
+            );
+        }
+    }
+}

--- a/src/evals/mod.rs
+++ b/src/evals/mod.rs
@@ -1,0 +1,189 @@
+//! offline ndcg eval harness for measuring search ranking quality.
+//!
+//! runs each query from a ground truth fixture against mem.search(),
+//! computes ndcg@5 and ndcg@10, and produces an aggregate report.
+//!
+//! pr2 will add centralised reporting — the report struct is already
+//! shaped for that (version, timestamp, blake3-hashed queries).
+
+pub mod ground_truth;
+pub mod ndcg;
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+pub use ground_truth::{EvalCase, EvalSuite};
+pub use ndcg::compute_ndcg;
+
+use crate::types::{SearchEngineKind, SearchRequest};
+use crate::{Memvid, Result};
+
+/// result for a single eval query
+#[derive(Debug, Clone)]
+pub struct QueryEvalResult {
+    pub query: String,
+    /// blake3 hex — the only id sent in pr2 (raw query stays local)
+    pub query_hash: String,
+    pub ndcg_at_5: f32,
+    pub ndcg_at_10: f32,
+    pub hit_count: usize,
+    pub elapsed_ms: u128,
+    pub engine: SearchEngineKind,
+    pub sketch_active: bool,
+}
+
+/// aggregate eval report — shaped for future centralised reporting in pr2
+#[derive(Debug, Clone)]
+pub struct EvalReport {
+    pub memvid_version: &'static str,
+    pub timestamp: i64,
+    pub mean_ndcg_at_5: f32,
+    pub mean_ndcg_at_10: f32,
+    pub cases_with_hits: usize,
+    pub total_cases: usize,
+    /// per-query detail (stays local, not sent in pr2)
+    pub per_query: Vec<QueryEvalResult>,
+}
+
+impl EvalReport {
+    pub fn print_summary(&self) {
+        println!("┌─────────────────────────────────────────────┐");
+        println!(
+            "│  Memvid NDCG Eval — v{:<23} │",
+            self.memvid_version
+        );
+        println!(
+            "│  Cases: {:<3}  Hits: {}/{}{}│",
+            self.total_cases,
+            self.cases_with_hits,
+            self.total_cases,
+            " ".repeat(18usize.saturating_sub(
+                format!("{}/{}", self.cases_with_hits, self.total_cases).len()
+            ))
+        );
+        println!("├───────────────────┬──────────┬──────────────┤");
+        println!("│ Metric            │  Score   │  Grade       │");
+        println!("├───────────────────┼──────────┼──────────────┤");
+        println!(
+            "│ Mean NDCG@5       │  {:.4}  │  {:<12} │",
+            self.mean_ndcg_at_5,
+            grade(self.mean_ndcg_at_5)
+        );
+        println!(
+            "│ Mean NDCG@10      │  {:.4}  │  {:<12} │",
+            self.mean_ndcg_at_10,
+            grade(self.mean_ndcg_at_10)
+        );
+        println!("└───────────────────┴──────────┴──────────────┘");
+    }
+
+    /// worst-first per-query breakdown
+    pub fn print_per_query(&self) {
+        let mut rows = self.per_query.clone();
+        rows.sort_by(|a, b| {
+            a.ndcg_at_5
+                .partial_cmp(&b.ndcg_at_5)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+        println!("\n{:<40} {:>8} {:>8}  {:>6}", "Query", "NDCG@5", "NDCG@10", "Hits");
+        println!("{}", "─".repeat(70));
+        for r in &rows {
+            let q = if r.query.len() > 38 {
+                format!("{}…", &r.query[..37])
+            } else {
+                r.query.clone()
+            };
+            println!(
+                "{:<40} {:>8.4} {:>8.4}  {:>6}",
+                q, r.ndcg_at_5, r.ndcg_at_10, r.hit_count
+            );
+        }
+    }
+}
+
+fn grade(score: f32) -> &'static str {
+    match score {
+        s if s >= 0.9 => "Excellent",
+        s if s >= 0.75 => "Good",
+        s if s >= 0.55 => "Fair",
+        s if s >= 0.35 => "Poor",
+        _ => "Very Poor",
+    }
+}
+
+/// run every case in the suite against mem.search() and return an aggregate report
+#[cfg(feature = "lex")]
+pub fn run_eval_suite(mem: &mut Memvid, suite: &EvalSuite) -> Result<EvalReport> {
+    let mut per_query: Vec<QueryEvalResult> = Vec::with_capacity(suite.cases.len());
+
+    for case in &suite.cases {
+        let request = SearchRequest {
+            query: case.query.clone(),
+            top_k: 10,
+            snippet_chars: 0,
+            uri: None,
+            scope: None,
+            cursor: None,
+            #[cfg(feature = "temporal_track")]
+            temporal: None,
+            as_of_frame: None,
+            as_of_ts: None,
+            no_sketch: false,
+            acl_context: None,
+            acl_enforcement_mode: crate::types::AclEnforcementMode::Audit,
+        };
+
+        let (hits, elapsed_ms, engine) = match mem.search(request) {
+            Ok(r) => (r.hits, r.elapsed_ms, r.engine),
+            Err(_) => (Vec::new(), 0, crate::types::SearchEngineKind::Tantivy),
+        };
+        let ndcg5 = compute_ndcg(&hits, case, 5);
+        let ndcg10 = compute_ndcg(&hits, case, 10);
+        let hit_count = hits.len();
+
+        let query_hash = blake3_hex(case.query.as_bytes());
+
+        per_query.push(QueryEvalResult {
+            query: case.query.clone(),
+            query_hash,
+            ndcg_at_5: ndcg5,
+            ndcg_at_10: ndcg10,
+            hit_count,
+            elapsed_ms,
+            engine,
+            sketch_active: !case.query.is_empty(),
+        });
+    }
+
+    let n = per_query.len() as f32;
+    let mean_ndcg_at_5 = if n > 0.0 {
+        per_query.iter().map(|r| r.ndcg_at_5).sum::<f32>() / n
+    } else {
+        0.0
+    };
+    let mean_ndcg_at_10 = if n > 0.0 {
+        per_query.iter().map(|r| r.ndcg_at_10).sum::<f32>() / n
+    } else {
+        0.0
+    };
+    let cases_with_hits = per_query.iter().filter(|r| r.hit_count > 0).count();
+
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0);
+
+    Ok(EvalReport {
+        memvid_version: crate::MEMVID_CORE_VERSION,
+        timestamp,
+        mean_ndcg_at_5,
+        mean_ndcg_at_10,
+        cases_with_hits,
+        total_cases: per_query.len(),
+        per_query,
+    })
+}
+
+pub(crate) fn blake3_hex(data: &[u8]) -> String {
+    let hash = blake3::hash(data);
+    hash.to_hex().to_string()
+}

--- a/src/evals/ndcg.rs
+++ b/src/evals/ndcg.rs
@@ -1,0 +1,193 @@
+//! pure ndcg computation — no io, no deps.
+//!
+//! ndcg measures ranked retrieval quality (0–1, higher = better).
+//! rewards both relevance grade and rank position, so burying
+//! the best result at rank 7 scores worse than having it at rank 1.
+
+use crate::types::SearchHit;
+
+use super::ground_truth::EvalCase;
+
+/// ndcg@k for a list of search hits vs ground truth. matches by uri.
+pub fn compute_ndcg(hits: &[SearchHit], case: &EvalCase, k: usize) -> f32 {
+    if k == 0 || case.relevant_uris.is_empty() {
+        return 0.0;
+    }
+
+    let grade_map: std::collections::HashMap<&str, f32> = case
+        .relevant_uris
+        .iter()
+        .zip(case.grades.iter())
+        .map(|(uri, &grade)| (uri.as_str(), grade))
+        .collect();
+
+    let actual_grades: Vec<f32> = hits
+        .iter()
+        .take(k)
+        .map(|hit| *grade_map.get(hit.uri.as_str()).unwrap_or(&0.0))
+        .collect();
+
+    let dcg = discounted_cumulative_gain(&actual_grades);
+
+    let mut ideal_grades: Vec<f32> = case.grades.clone();
+    ideal_grades.sort_by(|a, b| b.partial_cmp(a).unwrap_or(std::cmp::Ordering::Equal));
+    ideal_grades.truncate(k);
+    let idcg = discounted_cumulative_gain(&ideal_grades);
+
+    if idcg == 0.0 {
+        return 0.0;
+    }
+
+    (dcg / idcg).min(1.0)
+}
+
+/// dcg = sum of grade[i] / log2(rank + 1)
+fn discounted_cumulative_gain(grades: &[f32]) -> f32 {
+    grades
+        .iter()
+        .enumerate()
+        .map(|(i, &grade)| {
+            let rank = (i + 1) as f32; // 1-indexed rank
+            grade / (rank + 1.0_f32).log2()
+        })
+        .sum()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::evals::ground_truth::EvalCase;
+    use crate::types::SearchHit;
+
+    fn make_hit(uri: &str) -> SearchHit {
+        SearchHit {
+            rank: 0,
+            frame_id: 0,
+            uri: uri.to_string(),
+            title: None,
+            range: (0, 0),
+            text: String::new(),
+            matches: 0,
+            chunk_range: None,
+            chunk_text: None,
+            score: None,
+            metadata: None,
+        }
+    }
+
+    fn make_case(uris: &[&str], grades: &[f32]) -> EvalCase {
+        EvalCase {
+            query: "test query".to_string(),
+            relevant_uris: uris.iter().map(|s| s.to_string()).collect(),
+            grades: grades.to_vec(),
+        }
+    }
+
+    #[test]
+    fn perfect_ranking_scores_1() {
+        let hits = vec![make_hit("mv2://docs/wal.md"), make_hit("mv2://docs/other.md")];
+        let case = make_case(&["mv2://docs/wal.md"], &[1.0]);
+        let score = compute_ndcg(&hits, &case, 5);
+        assert!(
+            (score - 1.0).abs() < 1e-5,
+            "expected 1.0 got {score}"
+        );
+    }
+
+    #[test]
+    fn wrong_ranking_scores_less_than_perfect() {
+        let hits = vec![
+            make_hit("mv2://docs/secondary.md"),
+            make_hit("mv2://docs/primary.md"),
+        ];
+        let case = make_case(
+            &["mv2://docs/primary.md", "mv2://docs/secondary.md"],
+            &[1.0, 0.5],
+        );
+        let score = compute_ndcg(&hits, &case, 5);
+        assert!(score < 1.0, "expected score < 1.0 got {score}");
+        assert!(score > 0.0, "expected score > 0.0 got {score}");
+    }
+
+    #[test]
+    fn no_relevant_docs_in_hits_scores_0() {
+        let hits = vec![make_hit("mv2://docs/irrelevant.md")];
+        let case = make_case(&["mv2://docs/target.md"], &[1.0]);
+        let score = compute_ndcg(&hits, &case, 5);
+        assert_eq!(score, 0.0);
+    }
+
+    #[test]
+    fn empty_hits_scores_0() {
+        let hits: Vec<SearchHit> = vec![];
+        let case = make_case(&["mv2://docs/wal.md"], &[1.0]);
+        let score = compute_ndcg(&hits, &case, 5);
+        assert_eq!(score, 0.0);
+    }
+
+    #[test]
+    fn k_zero_scores_0() {
+        let hits = vec![make_hit("mv2://docs/wal.md")];
+        let case = make_case(&["mv2://docs/wal.md"], &[1.0]);
+        let score = compute_ndcg(&hits, &case, 0);
+        assert_eq!(score, 0.0);
+    }
+
+    #[test]
+    fn empty_ground_truth_scores_0() {
+        let hits = vec![make_hit("mv2://docs/wal.md")];
+        let case = make_case(&[], &[]);
+        let score = compute_ndcg(&hits, &case, 5);
+        assert_eq!(score, 0.0);
+    }
+
+    #[test]
+    fn graded_relevance_rank1_beats_rank2() {
+        let case = make_case(
+            &["mv2://docs/primary.md", "mv2://docs/secondary.md"],
+            &[1.0, 0.5],
+        );
+
+        let ideal_hits = vec![
+            make_hit("mv2://docs/primary.md"),
+            make_hit("mv2://docs/secondary.md"),
+        ];
+        let swapped_hits = vec![
+            make_hit("mv2://docs/secondary.md"),
+            make_hit("mv2://docs/primary.md"),
+        ];
+
+        let ideal_score = compute_ndcg(&ideal_hits, &case, 5);
+        let swapped_score = compute_ndcg(&swapped_hits, &case, 5);
+
+        assert!(
+            ideal_score > swapped_score,
+            "ideal {ideal_score} should beat swapped {swapped_score}"
+        );
+        assert!(
+            (ideal_score - 1.0).abs() < 1e-5,
+            "ideal ordering should be 1.0, got {ideal_score}"
+        );
+    }
+
+    #[test]
+    fn dcg_discount_decreases_with_rank() {
+        let hit_at_rank1 = vec![make_hit("mv2://target.md")];
+        let hit_at_rank5 = vec![
+            make_hit("mv2://irrelevant1.md"),
+            make_hit("mv2://irrelevant2.md"),
+            make_hit("mv2://irrelevant3.md"),
+            make_hit("mv2://irrelevant4.md"),
+            make_hit("mv2://target.md"),
+        ];
+        let case = make_case(&["mv2://target.md"], &[1.0]);
+
+        let score_rank1 = compute_ndcg(&hit_at_rank1, &case, 5);
+        let score_rank5 = compute_ndcg(&hit_at_rank5, &case, 5);
+
+        assert!(
+            score_rank1 > score_rank5,
+            "rank-1 score {score_rank1} should beat rank-5 score {score_rank5}"
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,6 +107,10 @@ pub mod simd;
 #[cfg(feature = "vec")]
 pub mod text_embed;
 
+/// offline search quality eval using ndcg scoring
+#[cfg(feature = "evals")]
+pub mod evals;
+
 // Triplet extraction module for automatic SPO extraction during ingestion
 pub mod triplet;
 

--- a/tests/evals.rs
+++ b/tests/evals.rs
@@ -1,0 +1,393 @@
+//! integration tests for the ndcg eval harness.
+//!
+//! - ndcg math tests: validate the formula with synthetic hits
+//! - fixture tests: make sure eval_fixtures.json loads and validates
+//! - end-to-end test: build a real .mv2, run the full suite, check scores
+
+#![cfg(feature = "evals")]
+#![cfg(feature = "lex")]
+
+use memvid_core::evals::{EvalSuite, run_eval_suite};
+use memvid_core::evals::ndcg::compute_ndcg;
+use memvid_core::evals::ground_truth::EvalCase;
+use memvid_core::types::SearchHit;
+use memvid_core::{Memvid, PutOptions, Result};
+use tempfile::tempdir;
+use std::sync::Mutex;
+
+static SERIAL: Mutex<()> = Mutex::new(());
+
+
+fn make_hit(uri: &str) -> SearchHit {
+    SearchHit {
+        rank: 0,
+        frame_id: 0,
+        uri: uri.to_string(),
+        title: None,
+        range: (0, 0),
+        text: String::new(),
+        matches: 0,
+        chunk_range: None,
+        chunk_text: None,
+        score: None,
+        metadata: None,
+    }
+}
+
+
+#[test]
+fn test_ndcg_math_perfect_score() {
+    let hits = vec![make_hit("mv2://a.md"), make_hit("mv2://b.md")];
+    let case = EvalCase {
+        query: "q".into(),
+        relevant_uris: vec!["mv2://a.md".into()],
+        grades: vec![1.0],
+    };
+    let score = compute_ndcg(&hits, &case, 5);
+    assert!((score - 1.0).abs() < 1e-5, "expected 1.0 got {score}");
+}
+
+#[test]
+fn test_ndcg_math_zero_when_miss() {
+    let hits = vec![make_hit("mv2://irrelevant.md")];
+    let case = EvalCase {
+        query: "q".into(),
+        relevant_uris: vec!["mv2://target.md".into()],
+        grades: vec![1.0],
+    };
+    let score = compute_ndcg(&hits, &case, 5);
+    assert_eq!(score, 0.0);
+}
+
+#[test]
+fn test_ndcg_math_rank_order_matters() {
+    let case = EvalCase {
+        query: "q".into(),
+        relevant_uris: vec!["mv2://primary.md".into(), "mv2://secondary.md".into()],
+        grades: vec![1.0, 0.5],
+    };
+    // Best doc at rank 1 → should score 1.0
+    let ideal = vec![make_hit("mv2://primary.md"), make_hit("mv2://secondary.md")];
+    // Best doc buried at rank 2 → should score < 1.0
+    let suboptimal = vec![make_hit("mv2://secondary.md"), make_hit("mv2://primary.md")];
+
+    let ideal_score = compute_ndcg(&ideal, &case, 5);
+    let sub_score = compute_ndcg(&suboptimal, &case, 5);
+
+    assert!((ideal_score - 1.0).abs() < 1e-5);
+    assert!(ideal_score > sub_score);
+}
+
+
+#[test]
+fn test_fixture_loads_and_validates() {
+    let suite = EvalSuite::from_embedded().expect("fixture must load");
+    assert!(!suite.is_empty(), "fixture must not be empty");
+    assert!(suite.len() >= 20, "expect at least 20 eval cases");
+}
+
+#[test]
+fn test_fixture_all_cases_have_at_least_one_relevant_uri() {
+    let suite = EvalSuite::from_embedded().unwrap();
+    for case in &suite.cases {
+        assert!(
+            !case.relevant_uris.is_empty(),
+            "case '{}' has no relevant URIs",
+            case.query
+        );
+        assert!(
+            !case.grades.is_empty(),
+            "case '{}' has no grades",
+            case.query
+        );
+    }
+}
+
+#[test]
+fn test_fixture_grades_are_valid() {
+    let suite = EvalSuite::from_embedded().unwrap();
+    for case in &suite.cases {
+        for &grade in &case.grades {
+            assert!(
+                (0.0..=1.0).contains(&grade),
+                "case '{}' has out-of-range grade {grade}",
+                case.query
+            );
+        }
+    }
+}
+
+#[test]
+fn test_filter_by_keyword() {
+    let suite = EvalSuite::from_embedded().unwrap();
+    let filtered = suite.filter_by_keyword("crash");
+    assert!(!filtered.is_empty(), "expected at least one 'crash' case");
+    for case in &filtered.cases {
+        assert!(case.query.to_lowercase().contains("crash"));
+    }
+}
+
+#[test]
+fn test_eval_suite_against_real_search() -> Result<()> {
+    let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
+    let dir = tempdir().expect("temp dir");
+    let path = dir.path().join("eval_test.mv2");
+
+    {
+        let mut mem = Memvid::create(&path)?;
+        mem.enable_lex()?;
+        insert_eval_corpus(&mut mem)?;
+        mem.commit()?;
+    }
+
+    let mut mem = Memvid::open_read_only(&path)?;
+
+    let suite = EvalSuite::from_embedded()?;
+    let report = run_eval_suite(&mut mem, &suite)?;
+
+    report.print_summary();
+    report.print_per_query();
+
+    assert_eq!(report.total_cases, suite.len());
+    assert!(
+        report.mean_ndcg_at_5 >= 0.0,
+        "NDCG@5 must be non-negative, got {}",
+        report.mean_ndcg_at_5
+    );
+    assert!(
+        report.cases_with_hits > 0,
+        "at least some eval queries should return hits from the corpus"
+    );
+    assert!(!report.memvid_version.is_empty());
+    for r in &report.per_query {
+        assert_eq!(r.query_hash.len(), 64, "blake3 hex should be 64 chars");
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_eval_wal_cases() -> Result<()> {
+    let _guard = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
+    let dir = tempdir().expect("temp dir");
+    let path = dir.path().join("eval_wal.mv2");
+
+    {
+        let mut mem = Memvid::create(&path)?;
+        mem.enable_lex()?;
+        insert_eval_corpus(&mut mem)?;
+        mem.commit()?;
+    }
+
+    let mut mem = Memvid::open_read_only(&path)?;
+    let suite = EvalSuite::from_embedded()?;
+    let wal_suite = suite.filter_by_keyword("wal");
+    assert!(!wal_suite.is_empty(), "fixture must contain at least one WAL case");
+
+    let report = run_eval_suite(&mut mem, &wal_suite)?;
+    println!("WAL-specific NDCG@5: {:.4}", report.mean_ndcg_at_5);
+
+    assert_eq!(report.total_cases, wal_suite.len());
+    assert!(report.mean_ndcg_at_5 >= 0.0);
+    Ok(())
+}
+
+/// synthetic docs with uris matching the eval fixtures so bm25 can find them
+fn insert_eval_corpus(mem: &mut Memvid) -> Result<()> {
+    let docs: &[(&str, &str, &str)] = &[
+        (
+            "mv2://docs/wal.md",
+            "Write-Ahead Log",
+            "The write-ahead log (WAL) is a circular buffer embedded in the mv2 file starting at \
+             byte 4096. It ensures crash safety by logging all mutations before they are flushed \
+             to data segments. The WAL checkpoint triggers at 75% full or every 1000 appends. \
+             During crash recovery the WAL is replayed to reconstruct the last committed state.",
+        ),
+        (
+            "mv2://docs/crash-safety.md",
+            "Crash Safety",
+            "Memvid is designed for crash safety. All writes go through the write-ahead log before \
+             being committed to data segments. In the event of a crash the WAL is replayed on next \
+             open to ensure no committed data is lost. The file lock prevents concurrent writers.",
+        ),
+        (
+            "mv2://docs/file-format.md",
+            "MV2 File Format",
+            "The mv2 single-file format consists of: Header (4KB), Embedded WAL (1-64MB), \
+             Data Segments, Lex Index (Tantivy), Vec Index (HNSW), Time Index, TOC (table of \
+             contents), and Footer (56 bytes). All sections are appended sequentially; frames are \
+             immutable once committed.",
+        ),
+        (
+            "mv2://docs/header.md",
+            "File Header",
+            "The mv2 file header occupies the first 4096 bytes (4KB) of the file. It stores \
+             magic bytes, format version, feature flags bitmask, root frame ID, WAL offset, \
+             and the Blake3 checksum of the header itself.",
+        ),
+        (
+            "mv2://docs/lex-index.md",
+            "Lexical Search Index",
+            "The lexical search index uses Tantivy BM25 full-text search. Indexed fields are: \
+             uri, title, content, tags, and dates. The index is stored as a Tantivy segment \
+             embedded in the mv2 file. Queries support AND, OR, phrase, and fuzzy matching.",
+        ),
+        (
+            "mv2://docs/vec-index.md",
+            "Vector Index",
+            "The vector similarity search index uses HNSW (Hierarchical Navigable Small World) \
+             for approximate nearest neighbour lookup. Below 1000 vectors a flat linear scan is \
+             used instead. The index is built using ONNX embeddings and stored in the mv2 file.",
+        ),
+        (
+            "mv2://docs/search.md",
+            "Search Architecture",
+            "Memvid supports lexical search (BM25 via Tantivy), vector similarity search (HNSW), \
+             and hybrid search combining both via Reciprocal Rank Fusion (RRF) with k=60. \
+             The sketch SimHash pre-filter generates candidate frames before full BM25 scoring. \
+             Search supports cursor pagination for large result sets.",
+        ),
+        (
+            "mv2://docs/sketch.md",
+            "Sketch Pre-filter",
+            "The sketch track stores a SimHash (locality sensitive hashing) fingerprint per frame. \
+             It is used as a sub-millisecond pre-filter to generate candidate frames before the \
+             more expensive BM25 or vector scoring. SimHash groups similar documents into the same \
+             bucket, enabling fast approximate candidate generation.",
+        ),
+        (
+            "mv2://docs/ask.md",
+            "RAG Ask Interface",
+            "The ask() API combines retrieval augmented generation (RAG) with hybrid search. \
+             It uses Reciprocal Rank Fusion (RRF) to merge lexical and semantic results. \
+             The adaptive retrieval mode dynamically adjusts top_k based on relevance score \
+             distribution. Analytical questions retrieve up to 5x more candidates for \
+             comprehensive context. Results are returned as AskContextFragment objects.",
+        ),
+        (
+            "mv2://docs/frame.md",
+            "Frame Design",
+            "Frames are immutable once committed. Each frame has a unique frame_id (u64), \
+             a URI, optional title and tags, compressed bytes payload, a Blake3 checksum, \
+             and a timestamp. The append-only design ensures deterministic checksums across \
+             operations.",
+        ),
+        (
+            "mv2://docs/mutation.md",
+            "Write Operations",
+            "The primary write operations are put_bytes() and put_bytes_with_options(). \
+             PutOptions allows setting uri, title, and tags via a builder pattern. \
+             All writes are buffered in the WAL and flushed on commit(). \
+             The commit() call flushes WAL frames to permanent data segments.",
+        ),
+        (
+            "mv2://docs/clip.md",
+            "CLIP Visual Embeddings",
+            "The clip feature flag enables CLIP image embeddings for visual search. \
+             CLIP encodes both images and text into the same embedding space, enabling \
+             cross-modal search. Embeddings are computed via an ONNX model and stored \
+             in the vector index.",
+        ),
+        (
+            "mv2://docs/whisper.md",
+            "Whisper Audio Transcription",
+            "The whisper feature flag enables audio transcription using OpenAI Whisper \
+             running locally via the Candle ML framework. Supported formats include MP3, \
+             WAV, FLAC, and AAC. Transcribed text is indexed in the lexical index.",
+        ),
+        (
+            "mv2://docs/encryption.md",
+            "Encryption Capsules",
+            "The encryption feature flag enables AES-256-GCM encryption for mv2e capsule files. \
+             Keys are derived via Argon2 from a user password. Encrypted capsules have the .mv2e \
+             extension. The encryption module uses zeroize to clear sensitive key material from memory.",
+        ),
+        (
+            "mv2://docs/timeline.md",
+            "Timeline and Time Index",
+            "The time index stores frames in chronological order, enabling timeline queries. \
+             timeline() returns frames sorted by insertion timestamp. Supports filtering by \
+             time range. Used by the ask() API for recency-biased queries.",
+        ),
+        (
+            "mv2://docs/replay.md",
+            "Time-Travel Replay",
+            "The replay feature enables time-travel views of the memory. SearchRequest supports \
+             as_of_frame and as_of_ts fields to restrict results to frames committed before \
+             a given frame ID or Unix timestamp. This allows agents to query the memory as it \
+             existed at any prior point in time.",
+        ),
+        (
+            "mv2://docs/mesh.md",
+            "Logic-Mesh Entity Graph",
+            "The logic_mesh feature flag enables a NER (Named Entity Recognition) entity \
+             relationship graph. Entities are extracted from frame content using DistilBERT-NER \
+             and stored in the TOC. The mesh enables structured relationship queries.",
+        ),
+        (
+            "mv2://docs/acl.md",
+            "Access Control Lists",
+            "The ACL system restricts search results based on caller identity. SearchRequest \
+             includes an optional acl_context field with caller identity. ACL enforcement \
+             mode can be audit (log violations) or enforce (filter results). Frame-level \
+             ACL tags are set at write time via PutOptions.",
+        ),
+        (
+            "mv2://docs/verify.md",
+            "File Verification",
+            "Memvid::verify() performs file integrity checks. Shallow verify checks the header \
+             and TOC checksums. Deep verify reads every frame and validates its Blake3 checksum. \
+             Returns a VerificationReport with overall_status and per-section results.",
+        ),
+        (
+            "mv2://docs/doctor.md",
+            "Doctor and Recovery",
+            "The doctor module performs health checks and recovery operations. It can detect \
+             and repair common corruption patterns, rebuild indices, and recover from partial \
+             WAL writes. The doctor report includes a detailed breakdown of all issues found.",
+        ),
+        (
+            "mv2://docs/checksums.md",
+            "Blake3 Checksums",
+            "Memvid uses Blake3 for all checksums: frame payload checksums, header checksums, \
+             and index checksums. Blake3 is chosen for its speed (faster than SHA-256) and \
+             security. Checksums are deterministic: the same content always produces the same \
+             Blake3 hash.",
+        ),
+        (
+            "mv2://docs/compression.md",
+            "Frame Compression",
+            "Frame bytes are compressed before storage. Supported codecs are zstd (default, \
+             best ratio) and lz4 (fast, lower ratio). The codec is stored per-frame in the \
+             frame header. Compression is applied transparently during put_bytes() and \
+             decompressed transparently during search and retrieval.",
+        ),
+        (
+            "mv2://docs/features.md",
+            "Feature Flags",
+            "Memvid uses Rust feature flags for conditional compilation. Default features are \
+             lex, pdf_extract, and simd. Optional features include vec, clip, whisper, \
+             encryption, temporal_track, logic_mesh, and api_embed. Feature flags are \
+             specified in Cargo.toml and guard code with #[cfg(feature = \"...\")].",
+        ),
+        (
+            "mv2://docs/lifecycle.md",
+            "Memvid Lifecycle",
+            "Memvid::create() creates a new mv2 file with an exclusive file lock. \
+             Memvid::open() opens an existing file for read-write access. The file lock \
+             ensures crash safety by preventing concurrent writers. Dropping the Memvid \
+             instance releases the lock and flushes any pending WAL entries.",
+        ),
+    ];
+
+    for (uri, title, content) in docs {
+        let opts = PutOptions::builder()
+            .uri(*uri)
+            .title(*title)
+            .search_text(*content)
+            .build();
+        mem.put_bytes_with_options(content.as_bytes(), opts)?;
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
hey @Olow304 @mo-omar-0197  went through the whole repo and noticed something worth fixing — we have no way to measure search quality. we track **elapsed_ms and total_hits** but nothing that tells us whether the right results are actually coming back first. speed is great, but if the best document is buried at rank 5, we'd never know.
so i built an ndcg eval harness as pr1.
what is ndcg? it's a standard search quality metric, scores 0 to 1. it specifically rewards putting the most relevant results at the top — a perfect result at rank 1 gets full credit, the same result at rank 5 gets about a third. this matters a lot for memvid because agents consume top-k hits as context. if the right chunk is buried, the agent misses it.
what's in this pr:

src/evals/ndcg.rs — pure ndcg computation, fully unit tested
src/evals/ground_truth.rs — loads eval cases from a json fixture file
src/evals/mod.rs — runs the full suite and prints a per-query + aggregate report
data/eval_fixtures.json — 30 hand-written query/answer pairs to start
tests/evals.rs — integration test that runs the harness against a real .mv2 file
all gated behind --features evals — zero impact on existing users

this is intentionally pr1 only — local, offline, no new dependencies, no network calls. but the EvalReport struct is already designed with memvid_version, timestamp, and query_hash fields so pr2 can plug straight in.

pr2 needs your input
pr2 would hook into mem.search() and post eval reports to a central endpoint in the background — fire and forget, zero latency impact, raw queries are never sent (hashed with blake3 for privacy). but before i build it i need two things from you:
one — can we add an opt-in telemetry flag? this is a trust and policy decision more than a technical one.
two — where do we stand up the reporting endpoint? doesn't need to be complex — a cloudflare worker or simple supabase instance would do it.

the ground truth question
the 30 fixtures i wrote are synthetic — i invented questions about memvid internals. they're good enough to catch regressions in ci but they don't reflect real user queries. to make this meaningful in production we need ground truth from real usage. a few directions i see:
the ai bully job data — real users searched for real things, we know which results were right. that's ready-made ground truth with no llm needed, just needs to be formatted into the fixture file.
telemetry — once the opt-in endpoint exists, we collect query hashes + returned uris, then periodically run an llm judge offline to grade results and promote the best cases into the fixture file. automated and scales naturally.
direct user sessions — find 2-3 opted-in users, watch what they search for, mark the right answers manually. even 20 real cases would be more valuable than our current 30 synthetic ones.
would love your thoughts on which direction makes sense before building pr2.