### PR TITLE
fix(io): bound malformed index allocation to bytes read

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3152,7 +3152,7 @@ dependencies = [
 
 [[package]]
 name = "memvid-core"
-version = "2.0.135"
+version = "2.0.139"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3152,7 +3152,7 @@ dependencies = [
 
 [[package]]
 name = "memvid-core"
-version = "2.0.139"
+version = "2.0.140"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/src/io/temporal_index.rs
+++ b/src/io/temporal_index.rs
@@ -19,6 +19,12 @@ const MENTION_RECORD_SIZE: usize = 32; // padded to 32 bytes for alignment
 const ANCHOR_RECORD_SIZE: usize = 24;
 const MAX_TEMPORAL_TRACK_BYTES: u64 = 1 << 34; // 16 GiB safety ceiling
 
+/// Initial capacity for decoded mention/anchor vectors. Bounds the *eager*
+/// allocation driven by the on-disk header counts — both vectors still grow
+/// to fit all records the reader delivers, but a hostile count no longer
+/// reserves count-proportional memory before any record is read.
+const INITIAL_RECORDS_CAPACITY: usize = 1024;
+
 #[derive(Debug, Clone, Copy)]
 struct RawMention {
     ts_utc: i64,
@@ -298,37 +304,49 @@ pub fn read_track<R: Read + Seek>(
         });
     }
 
-    // Safe: length validated against MAX_TEMPORAL_TRACK_BYTES (16 GiB) on line 247
-    // and HEADER_SIZE is constant, so result fits in usize
-    let mut body = vec![0u8; (length - HEADER_SIZE as u64) as usize];
-    reader.read_exact(&mut body)?;
-
+    // Stream records one at a time rather than slurping the whole body into a
+    // single `Vec<u8>`. A hostile but self-consistent header with
+    // `length ≈ MAX_TEMPORAL_TRACK_BYTES` (and matching counts) would
+    // otherwise force a ~16 GiB body allocation before any payload byte is
+    // validated; here, both the hasher and the decoded vectors grow only as
+    // `read_exact` succeeds.
     let mut header_for_hash = header;
     header_for_hash[CHECKSUM_OFFSET..CHECKSUM_OFFSET + 32].fill(0);
     let mut hasher = Hasher::new();
     hasher.update(&header_for_hash);
-    hasher.update(&body);
+
+    // Safe: counts validated by checked_mul and total_expected == length check
+    // above. The eager Vec capacity is clamped to bound up-front allocation;
+    // the vector grows as records are decoded. The result of the `min` always
+    // fits in usize because INITIAL_RECORDS_CAPACITY is a usize literal.
+    #[allow(clippy::cast_possible_truncation)]
+    let mentions_initial = entry_count.min(INITIAL_RECORDS_CAPACITY as u64) as usize;
+    #[allow(clippy::cast_possible_truncation)]
+    let anchors_initial = anchor_count.min(INITIAL_RECORDS_CAPACITY as u64) as usize;
+    let mut mentions = Vec::with_capacity(mentions_initial);
+    let mut anchors = Vec::with_capacity(anchors_initial);
+
+    let mut mention_buf = [0u8; MENTION_RECORD_SIZE];
+    for _ in 0..entry_count {
+        reader.read_exact(&mut mention_buf)?;
+        hasher.update(&mention_buf);
+        let raw = RawMention::decode(&mention_buf)?;
+        mentions.push(raw.into_high_level()?);
+    }
+
+    let mut anchor_buf = [0u8; ANCHOR_RECORD_SIZE];
+    for _ in 0..anchor_count {
+        reader.read_exact(&mut anchor_buf)?;
+        hasher.update(&anchor_buf);
+        let raw = RawAnchor::decode(&anchor_buf)?;
+        anchors.push(raw.into_high_level()?);
+    }
+
     let computed = *hasher.finalize().as_bytes();
     if computed != checksum {
         return Err(MemvidError::InvalidTemporalTrack {
             reason: "checksum mismatch".into(),
         });
-    }
-
-    // Safe: counts validated by checked_mul and total_expected == length check above
-    let mut mentions = Vec::with_capacity(entry_count as usize);
-    let mut anchors = Vec::with_capacity(anchor_count as usize);
-
-    // Safe: validated by checked_mul overflow check on line 283
-    let mentions_bytes = expected_entries_bytes as usize;
-    for chunk in body[..mentions_bytes].chunks_exact(MENTION_RECORD_SIZE) {
-        let raw = RawMention::decode(chunk)?;
-        mentions.push(raw.into_high_level()?);
-    }
-
-    for chunk in body[mentions_bytes..].chunks_exact(ANCHOR_RECORD_SIZE) {
-        let raw = RawAnchor::decode(chunk)?;
-        anchors.push(raw.into_high_level()?);
     }
 
     validate_mentions_sorted(&mentions)?;
@@ -552,5 +570,60 @@ mod tests {
             validate_anchors_sorted(&anchors),
             Err(MemvidError::InvalidTemporalTrack { .. })
         ));
+    }
+
+    #[test]
+    fn read_rejects_oversized_declared_length() {
+        // Anything strictly above the safety ceiling must be rejected before
+        // a body buffer is allocated.
+        let mut buf = Vec::new();
+        let mut cursor = std::io::Cursor::new(&mut buf);
+        let err = read_track(&mut cursor, 0, MAX_TEMPORAL_TRACK_BYTES + 1)
+            .expect_err("oversized declared length must be rejected");
+        match err {
+            MemvidError::InvalidTemporalTrack { reason } => {
+                assert!(reason.contains("length"), "unexpected reason: {reason}");
+            }
+            other => panic!("expected InvalidTemporalTrack, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn read_at_cap_does_not_eagerly_allocate_count_proportional_memory() {
+        // Construct a header whose declared length sits just under
+        // MAX_TEMPORAL_TRACK_BYTES with matching counts. This is the largest
+        // value that passes the ceiling check and the count consistency check,
+        // and is the case that previously allocated ~16 GiB body buffer plus
+        // count-proportional Vec capacity before any record was decoded.
+        //
+        // With streaming reads + clamped Vec capacity, the function must fail
+        // fast at the first body `read_exact` because only the header bytes
+        // are present.
+        let total_body = MAX_TEMPORAL_TRACK_BYTES - HEADER_SIZE as u64;
+        let entry_count = total_body / MENTION_RECORD_SIZE as u64;
+        let anchor_count = 0u64;
+        let declared_length = HEADER_SIZE as u64 + entry_count * MENTION_RECORD_SIZE as u64;
+        assert!(declared_length <= MAX_TEMPORAL_TRACK_BYTES);
+
+        let flags: u16 = 0;
+        let mut header = [0u8; HEADER_SIZE];
+        header[0..4].copy_from_slice(&TEMPORAL_TRACK_MAGIC);
+        header[4..6].copy_from_slice(&TEMPORAL_TRACK_VERSION.to_le_bytes());
+        header[6..8].copy_from_slice(&flags.to_le_bytes());
+        header[8..16].copy_from_slice(&entry_count.to_le_bytes());
+        header[16..24].copy_from_slice(&anchor_count.to_le_bytes());
+        // checksum bytes stay zero — the loop won't reach the checksum check
+        // because the first body read_exact will fail first.
+
+        let mut cursor = std::io::Cursor::new(header.to_vec());
+        let err = read_track(&mut cursor, 0, declared_length)
+            .expect_err("near-cap aligned length must fail at body read, not succeed");
+        assert!(
+            matches!(
+                &err,
+                MemvidError::Io { source, .. } if source.kind() == std::io::ErrorKind::UnexpectedEof
+            ),
+            "expected UnexpectedEof, got {err:?}",
+        );
     }
 }

--- a/src/io/time_index.rs
+++ b/src/io/time_index.rs
@@ -7,6 +7,12 @@ use crate::{
     error::{MemvidError, Result},
 };
 
+/// Safety ceiling on declared time-index track length. A malformed or hostile
+/// `.mv2` can declare an arbitrarily large `bytes_length` in its TOC; without
+/// this cap, `read_track` would allocate proportional capacity before the
+/// later `read_exact` would fail. 16 GiB matches the temporal-index ceiling.
+const MAX_TIME_INDEX_BYTES: u64 = 1 << 34;
+
 /// Raw entry used to build the time index track.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct TimeIndexEntry {
@@ -63,6 +69,12 @@ pub fn read_track<R: Read + Seek>(
     offset: u64,
     length: u64,
 ) -> Result<Vec<TimeIndexEntry>> {
+    if length > MAX_TIME_INDEX_BYTES {
+        return Err(MemvidError::InvalidTimeIndex {
+            reason: "length exceeds supported limit".into(),
+        });
+    }
+
     reader.seek(SeekFrom::Start(offset))?;
 
     let mut magic = [0u8; 4];
@@ -189,6 +201,21 @@ mod tests {
         file.seek(SeekFrom::Start(0)).unwrap();
         let err = read_track(&mut file, 0, length).expect_err("unsorted entries must fail");
         matches!(err, MemvidError::InvalidTimeIndex { .. });
+    }
+
+    #[test]
+    fn read_rejects_oversized_declared_length() {
+        // Hostile or malformed TOC declaring a length above the safety ceiling
+        // must be rejected before any capacity allocation happens.
+        let mut file = tempfile().expect("temp file");
+        let err = read_track(&mut file, 0, MAX_TIME_INDEX_BYTES + 1)
+            .expect_err("oversized length must be rejected");
+        match err {
+            MemvidError::InvalidTimeIndex { reason } => {
+                assert!(reason.contains("length"), "unexpected reason: {reason}");
+            }
+            other => panic!("expected InvalidTimeIndex, got {other:?}"),
+        }
     }
 
     #[test]

--- a/src/io/time_index.rs
+++ b/src/io/time_index.rs
@@ -13,6 +13,12 @@ use crate::{
 /// later `read_exact` would fail. 16 GiB matches the temporal-index ceiling.
 const MAX_TIME_INDEX_BYTES: u64 = 1 << 34;
 
+/// Initial `Vec` capacity for the decoded entries. Bounds the *eager*
+/// allocation driven by the on-disk `count` field — the vector still grows
+/// to fit all entries that the reader successfully delivers, but a hostile
+/// `count` no longer reserves count-proportional memory up front.
+const INITIAL_ENTRIES_CAPACITY: usize = 1024;
+
 /// Raw entry used to build the time index track.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct TimeIndexEntry {
@@ -107,9 +113,13 @@ pub fn read_track<R: Read + Seek>(
         });
     }
 
-    // Safe: count validated by checked_mul and payload_bytes comparison above
+    // Clamp the eager allocation: a hostile `count` aligned just under
+    // MAX_TIME_INDEX_BYTES would otherwise reserve ~16 GiB before any byte of
+    // payload is read. The vector still grows as `read_exact` succeeds, so the
+    // committed memory tracks what the file actually delivers.
     #[allow(clippy::cast_possible_truncation)]
-    let mut entries = Vec::with_capacity(count as usize);
+    let initial_capacity = (count as usize).min(INITIAL_ENTRIES_CAPACITY);
+    let mut entries = Vec::with_capacity(initial_capacity);
     let mut prev: Option<TimeIndexEntry> = None;
     for _ in 0..count {
         let mut ts_buf = [0u8; 8];
@@ -216,6 +226,43 @@ mod tests {
             }
             other => panic!("expected InvalidTimeIndex, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn read_at_cap_does_not_eagerly_allocate_count_proportional_memory() {
+        // Largest aligned, accepted declared length: declared_length ==
+        // MAX_TIME_INDEX_BYTES, count == (MAX_TIME_INDEX_BYTES - header)/16.
+        // This passes the length-ceiling check and the count*16 == payload
+        // check, so it exercises the same code path that previously allocated
+        // count-proportional capacity (~16 GiB) before any payload byte was
+        // read. With the clamped initial capacity, the reader should commit
+        // only `INITIAL_ENTRIES_CAPACITY` slots worth (~16 KiB), then fail at
+        // the first `read_exact` because the file body is empty.
+        const ENTRY_SIZE: u64 = 16;
+        let header_len = 4u64 + 8;
+        let count = (MAX_TIME_INDEX_BYTES - header_len) / ENTRY_SIZE;
+        let declared_length = header_len + count * ENTRY_SIZE;
+        assert!(declared_length <= MAX_TIME_INDEX_BYTES);
+
+        // Provide only the 12-byte header so any count-driven body read fails
+        // fast with UnexpectedEof, rather than tying up real memory.
+        let mut buf = Vec::with_capacity(12);
+        buf.extend_from_slice(&TIME_INDEX_MAGIC);
+        buf.extend_from_slice(&count.to_le_bytes());
+        let mut cursor = std::io::Cursor::new(buf);
+
+        let err = read_track(&mut cursor, 0, declared_length)
+            .expect_err("near-cap aligned length must fail at body read, not succeed");
+        // The function reached the read loop and ran out of bytes — proving it
+        // did not silently complete and that the eager allocation was bounded
+        // (otherwise the test process would have requested ~16 GiB up front).
+        assert!(
+            matches!(
+                &err,
+                MemvidError::Io { source, .. } if source.kind() == std::io::ErrorKind::UnexpectedEof
+            ),
+            "expected UnexpectedEof, got {err:?}",
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`io::time_index::read_track` and `io::temporal_index::read_track` accept an on-disk `length` and `count`/`entry_count` and use them to size up-front allocations before validating any payload. A self-consistent but adversarially constructed `.mv2` can declare values that satisfy the structural checks but drive ~16 GiB of allocation per call.

This PR closes that gap on both readers. The 16 GiB ceiling (`MAX_TIME_INDEX_BYTES` / `MAX_TEMPORAL_TRACK_BYTES`) is preserved as a defence-in-depth upper bound — the actual fix is to bound the *eager* allocation to what the file has actually delivered.

## Changes

**`src/io/time_index.rs`**
- Add `MAX_TIME_INDEX_BYTES = 1 << 34` (16 GiB) and reject declared lengths above it (mirrors the temporal-index reader).
- Clamp `Vec::with_capacity(count)` to `INITIAL_ENTRIES_CAPACITY = 1024`. The vector still grows naturally as `read_exact` succeeds, so the committed memory tracks the payload actually read.

**`src/io/temporal_index.rs`**
- Drop the body-slurp (`vec![0u8; length - HEADER_SIZE]`) — records are now streamed one at a time into a fixed-size stack buffer (`[u8; MENTION_RECORD_SIZE]`, `[u8; ANCHOR_RECORD_SIZE]`), hashed incrementally, and decoded directly into the output vectors.
- Clamp `Vec::with_capacity(entry_count)` / `Vec::with_capacity(anchor_count)` to `INITIAL_RECORDS_CAPACITY = 1024`. Same growth semantics as above.

## Why this matters (response to review)

The previous revision of this PR only enforced the ceiling. A near-cap aligned input (`declared_length = 17_179_869_180`, `count = 1_073_741_823`) passed both the ceiling check and the `count * 16 == payload_bytes` check, so `Vec::with_capacity(count)` still asked the allocator for ~16 GiB before any payload byte was read. With this revision, the same input commits only `INITIAL_ENTRIES_CAPACITY` slots up front (~16 KiB) and then fails at the first `read_exact` with `UnexpectedEof`.

The same shape existed — and is now fixed — in the temporal-index reader.

## Tests

Two new near-cap boundary tests, one per reader. Each constructs the largest aligned, accepted declared length, provides only the header bytes, and asserts that `read_track` returns `Io { UnexpectedEof, .. }` rather than completing or OOMing. If the eager-allocation path were still wide open, the test process would have requested ~16 GiB up front and the test would be unrunnable on a normal machine.

- [x] `cargo test --lib` — 340/340 pass
- [x] `cargo test --lib --features temporal_track` — 346/346 pass
- [x] `cargo clippy --lib --no-deps` — clean
- [x] `cargo fmt -- --check` — clean

## Notes

- No public API change.
- The `Cargo.lock` bump (`2.0.135` → `2.0.139`) is a lockfile sync with workspace version on `main` (released in `a79dfdd`), not an incidental dep upgrade.
- AI-assistance disclosure: parts of this revision were drafted with the help of an AI coding assistant; all changes were reviewed and tested locally before commit.