### PR TITLE
fix(types): implement Default for SearchRequest

### DIFF
--- a/src/types/search.rs
+++ b/src/types/search.rs
@@ -37,6 +37,16 @@ impl Default for SearchEngineKind {
 }
 
 /// Search request accepted by the core; supports lexical, hybrid, and temporal filters.
+///
+/// Implements [`Default`] so callers can use struct-update syntax:
+///
+/// ```rust,ignore
+/// let req = SearchRequest {
+///     query: "my query".into(),
+///     top_k: 5,
+///     ..Default::default()
+/// };
+/// ```
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SearchRequest {
     /// Query string (lexical or semantic depending on engine).
@@ -70,8 +80,33 @@ pub struct SearchRequest {
     /// Optional caller identity context used for ACL filtering.
     pub acl_context: Option<AclContext>,
     #[serde(default)]
-    /// ACL evaluation mode (`audit` or `enforce`).
+    /// ACL enforcement mode (`audit` or `enforce`).
     pub acl_enforcement_mode: AclEnforcementMode,
+}
+
+impl Default for SearchRequest {
+    /// Returns a `SearchRequest` with an empty query, `top_k = 10`, `snippet_chars = 200`,
+    /// and all optional fields set to their zero/none values.
+    ///
+    /// Intended for use with struct-update syntax so callers only need to specify the
+    /// fields that differ from these defaults.
+    fn default() -> Self {
+        Self {
+            query: String::new(),
+            top_k: 10,
+            snippet_chars: 200,
+            uri: None,
+            scope: None,
+            cursor: None,
+            #[cfg(feature = "temporal_track")]
+            temporal: None,
+            as_of_frame: None,
+            as_of_ts: None,
+            no_sketch: false,
+            acl_context: None,
+            acl_enforcement_mode: AclEnforcementMode::default(),
+        }
+    }
 }
 
 /// A single ranked hit with snippet metadata.


### PR DESCRIPTION
## Problem

The Quick Start example in README uses struct-update syntax when constructing a `SearchRequest`:

```rust
let response = mem.search(SearchRequest {
    query: "planning".into(),
    top_k: 10,
    snippet_chars: 200,
    ..Default::default()
})?;
```

However, `SearchRequest` does not implement `Default`, so this code fails to compile with:

```
error[E0277]: the trait bound `SearchRequest: Default` is not satisfied
```

Reported in #221.

## Fix

Add an explicit `Default` implementation for `SearchRequest` with sensible values:

- `query`: empty `String` (callers override via struct-update)
- `top_k`: `10`
- `snippet_chars`: `200`
- all optional / flag fields: `None` / `false` / enum defaults

This makes the README Quick Start compile without changes, and gives library users the ergonomic struct-update pattern they already expect.

## Testing

The change is purely additive — a new `impl Default` block. Existing code is unaffected. The fix can be verified with:

```rust
let _ = SearchRequest { query: "hello".into(), ..Default::default() };
```