### PR TITLE
Makeover of the README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
 <p align="center">
     <a href="https://trendshift.io/repositories/17293" target="_blank"><img src="https://trendshift.io/api/badge/repositories/17293" alt="memvid%2Fmemvid | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
 </p>
-<!-- BADGES:END -->
 
 <p align="center">
   <strong>Memvid is a single-file memory layer for AI agents with instant retrieval and long-term memory.</strong><br/>
@@ -24,6 +23,8 @@
   <a href="https://docs.memvid.com">Docs</a>
   ·
   <a href="https://github.com/memvid/memvid/discussions">Discussions</a>
+  ·
+  <a href="docs/i18n/translation_hub.md">Translations</a>
 </p>
 <!-- NAV:END -->
 
@@ -40,6 +41,7 @@
   <a href="https://github.com/memvid/memvid/issues"><img src="https://img.shields.io/github/issues/memvid/memvid?style=flat-square&logo=github" alt="Issues" /></a>
   <a href="https://discord.gg/2mynS7fcK7"><img src="https://img.shields.io/discord/1442910055233224745?style=flat-square&logo=discord&label=discord" alt="Discord" /></a>
 </p>
+<!-- BADGES:END -->
 
 
 ## Benchmark Highlights

--- a/docs/i18n/README.ar.md
+++ b/docs/i18n/README.ar.md
@@ -1,23 +1,22 @@
 <!-- HEADER:START -->
-<img width="2000" height="524" alt="Social Cover (9)" src="https://github.com/user-attachments/assets/cf66f045-c8be-494b-b696-b8d7e4fb709c" />
+<img width="2000" height="524" alt="Social Cover (9)"
+     src="https://github.com/user-attachments/assets/cf66f045-c8be-494b-b696-b8d7e4fb709c" />
 <!-- HEADER:END -->
 
-<!-- FLAGS:START -->
+<div style="height: 16px;"></div>
+
+# المساهمة في Memvid (الترجمة العربية)
+
 <p align="center">
- <a href="../../README.md">🇺🇸 English</a>
- <a href="README.es.md">🇪🇸 Español</a>
- <a href="README.fr.md">🇫🇷 Français</a>
- <a href="README.so.md">🇸🇴 Soomaali</a>
- <a href="README.ar.md">🇸🇦 العربية</a>
- <a href="README.nl.md">🇧🇪/🇳🇱 Nederlands</a>
- <a href="README.hi.md">🇮🇳 हिन्दी</a>
- <a href="README.bn.md">🇧🇩 বাংলা</a>
- <a href="README.cs.md">🇨🇿 Čeština</a>
- <a href="README.ko.md">🇰🇷 한국어</a>
- <a href="README.ja.md">🇯🇵 日本語</a>
- <!-- Next Flag -->
+    <a href="https://trendshift.io/repositories/17293" target="_blank"><img src="https://trendshift.io/api/badge/repositories/17293" alt="memvid%2Fmemvid | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
 </p>
-<!-- FLAGS:END -->
+
+<p align="center">
+<strong>Memvid هي طبقة ذاكرة مكونة من ملف واحد لوكلاء الذكاء الاصطناعي (AI Agents)، توفر استرجاعاً فورياً وذاكرة طويلة المدى.</strong>
+
+ذاكرة دائمة، مؤرشفة، وقابلة للنقل، دون الحاجة إلى قواعد بيانات.
+
+</p>
 
 <!-- NAV:START -->
 <p align="center">
@@ -28,6 +27,8 @@
   <a href="https://docs.memvid.com">Docs</a>
   ·
   <a href="https://github.com/memvid/memvid/discussions">Discussions</a>
+  ·
+  <a href="docs/i18n/translation_hub.md">Translations</a>
 </p>
 <!-- NAV:END -->
 
@@ -44,20 +45,7 @@
   <a href="https://github.com/memvid/memvid/issues"><img src="https://img.shields.io/github/issues/memvid/memvid?style=flat-square&logo=github" alt="Issues" /></a>
   <a href="https://discord.gg/2mynS7fcK7"><img src="https://img.shields.io/discord/1442910055233224745?style=flat-square&logo=discord&label=discord" alt="Discord" /></a>
 </p>
-
-<p align="center">
-    <a href="https://trendshift.io/repositories/17293" target="_blank"><img src="https://trendshift.io/api/badge/repositories/17293" alt="memvid%2Fmemvid | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
-</p>
 <!-- BADGES:END -->
-
-# المساهمة في Memvid (الترجمة العربية)
-
-<p align="center">
-<strong>Memvid هي طبقة ذاكرة مكونة من ملف واحد لوكلاء الذكاء الاصطناعي (AI Agents)، توفر استرجاعاً فورياً وذاكرة طويلة المدى.</strong>
-
-ذاكرة دائمة، مؤرشفة، وقابلة للنقل، دون الحاجة إلى قواعد بيانات.
-
-</p>
 
 <h2 align="center">⭐️ اترك نجمة (STAR) لدعم المشروع ⭐️</h2>
 

--- a/docs/i18n/README.bn.md
+++ b/docs/i18n/README.bn.md
@@ -1,63 +1,22 @@
 <!-- HEADER:START -->
-<img width="2000" height="524" alt="Social Cover (9)" src="https://github.com/user-attachments/assets/cf66f045-c8be-494b-b696-b8d7e4fb709c" />
+<img width="2000" height="524" alt="Social Cover (9)"
+     src="https://github.com/user-attachments/assets/cf66f045-c8be-494b-b696-b8d7e4fb709c" />
 <!-- HEADER:END -->
 
-<!-- FLAGS:START -->
-<p align="center">
- <a href="../../README.md">🇺🇸 English</a>
- <a href="README.es.md">🇪🇸 Español</a>
- <a href="README.fr.md">🇫🇷 Français</a>
- <a href="README.so.md">🇸🇴 Soomaali</a>
- <a href="README.ar.md">🇸🇦 العربية</a>
- <a href="README.nl.md">🇧🇪/🇳🇱 Nederlands</a>
- <a href="README.hi.md">🇮🇳 हिन्दी</a>
- <a href="README.bn.md">🇧🇩 বাংলা</a>
- <a href="README.cs.md">🇨🇿 Čeština</a>
- <a href="README.ko.md">🇰🇷 한국어</a>
- <a href="README.ja.md">🇯🇵 日本語</a>
- <!-- Next Flag -->
-</p>
-<!-- FLAGS:END -->
-
-<!-- NAV:START -->
-<p align="center">
-  <a href="https://www.memvid.com">Website</a>
-  ·
-  <a href="https://sandbox.memvid.com">Try Sandbox</a>
-  ·
-  <a href="https://docs.memvid.com">Docs</a>
-  ·
-  <a href="https://github.com/memvid/memvid/discussions">Discussions</a>
-</p>
-<!-- NAV:END -->
-
-<!-- BADGES:START -->
-<p align="center">
-  <a href="https://crates.io/crates/memvid-core"><img src="https://img.shields.io/crates/v/memvid-core?style=flat-square&logo=rust" alt="Crates.io" /></a>
-  <a href="https://docs.rs/memvid-core"><img src="https://img.shields.io/docsrs/memvid-core?style=flat-square&logo=docs.rs" alt="docs.rs" /></a>
-  <a href="https://github.com/memvid/memvid/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="License" /></a>
-</p>
-
-<p align="center">
-  <a href="https://github.com/memvid/memvid/stargazers"><img src="https://img.shields.io/github/stars/memvid/memvid?style=flat-square&logo=github" alt="Stars" /></a>
-  <a href="https://github.com/memvid/memvid/network/members"><img src="https://img.shields.io/github/forks/memvid/memvid?style=flat-square&logo=github" alt="Forks" /></a>
-  <a href="https://github.com/memvid/memvid/issues"><img src="https://img.shields.io/github/issues/memvid/memvid?style=flat-square&logo=github" alt="Issues" /></a>
-  <a href="https://discord.gg/2mynS7fcK7"><img src="https://img.shields.io/discord/1442910055233224745?style=flat-square&logo=discord&label=discord" alt="Discord" /></a>
-</p>
-
-<p align="center">
-    <a href="https://trendshift.io/repositories/17293" target="_blank"><img src="https://trendshift.io/api/badge/repositories/17293" alt="memvid%2Fmemvid | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
-</p>
-<!-- BADGES:END -->
-
+<div style="height: 16px;"></div>
 
 # মেমভিড-এ অবদান (বাংলা অনুবাদ)
+
+<p align="center">
+    <a href="https://trendshift.io/repositories/17293" target="_blank"><img src="https://trendshift.io/api/badge/repositories/17293" alt="memvid%2Fmemvid | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"></a>
+</p>
 
 <p align="center">
   <strong>মেমভিড হল এআই এজেন্টদের জন্য একটি একক-ফাইল মেমরি স্তর যার তাৎক্ষণিক পুনরুদ্ধার এবং দীর্ঘমেয়াদী মেমরি রয়েছে।</strong><br/>
   ডাটাবেস ছাড়াই স্থায়ী, সংস্করণযুক্ত এবং পোর্টেবল মেমরি।
 </p>
 
+<!-- NAV:START -->
 <p align="center">
   <a href="https://www.memvid.com">ওয়েবসাইট</a>
   ·
@@ -66,7 +25,10 @@
   <a href="https://docs.memvid.com">ডক্স</a>
   ·
   <a href="https://github.com/memvid/memvid/discussions">আলোচনা</a>
+  ·
+  <a href="docs/i18n/translation_hub.md">Translations</a>
 </p>
+<!-- NAV:END -->
 
 <p align="center">
   <a href="https://crates.io/crates/memvid-core"><img src="https://img.shields.io/crates/v/memvid-core?style=flat-square&logo=rust" alt="Crates.io" /></a>
@@ -74,16 +36,14 @@
   <a href="https://github.com/memvid/memvid/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="License" /></a>
 </p>
 
+<!-- BADGES:START -->
 <p align="center">
   <a href="https://github.com/memvid/memvid/stargazers"><img src="https://img.shields.io/github/stars/memvid/memvid?style=flat-square&logo=github" alt="Stars" /></a>
   <a href="https://github.com/memvid/memvid/network/members"><img src="https://img.shields.io/github/forks/memvid/memvid?style=flat-square&logo=github" alt="Forks" /></a>
   <a href="https://github.com/memvid/memvid/issues"><img src="https://img.shields.io/github/issues/memvid/memvid?style=flat-square&logo=github" alt="Issues" /></a>
   <a href="https://discord.gg/2mynS7fcK7"><img src="https://img.shields.io/discord/1442910055233224745?style=flat-square&logo=discord&label=discord" alt="Discord" /></a>
 </p>
-
-<p align="center">
-    <a href="https://trendshift.io/repositories/17293" target="_blank"><img src="https://trendshift.io/api/badge/repositories/17293" alt="memvid%2Fmemvid | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/</a>
-</p>
+<!-- BADGES:END -->
 
 <h2 align="center">⭐️ প্রকল্পটি সমর্থন করার জন্য একটি তারকা দিন। ⭐️</h2>
 </p>

--- a/docs/i18n/README.cs.md
+++ b/docs/i18n/README.cs.md
@@ -2,22 +2,16 @@
 <img width="2000" height="524" alt="Social Cover (9)" src="https://github.com/user-attachments/assets/cf66f045-c8be-494b-b696-b8d7e4fb709c" />
 <!-- HEADER:END -->
 
-<!-- FLAGS:START -->
+<div style="height: 16px;"></div>
+
 <p align="center">
- <a href="../../README.md">🇺🇸 English</a>
- <a href="README.es.md">🇪🇸 Español</a>
- <a href="README.fr.md">🇫🇷 Français</a>
- <a href="README.so.md">🇸🇴 Soomaali</a>
- <a href="README.ar.md">🇸🇦 العربية</a>
- <a href="README.nl.md">🇧🇪/🇳🇱 Nederlands</a>
- <a href="README.hi.md">🇮🇳 हिन्दी</a>
- <a href="README.bn.md">🇧🇩 বাংলা</a>
- <a href="README.cs.md">🇨🇿 Čeština</a>
- <a href="README.ko.md">🇰🇷 한국어</a>
- <a href="README.ja.md">🇯🇵 日本語</a>
- <!-- Next Flag -->
+    <a href="https://trendshift.io/repositories/17293" target="_blank"><img src="https://trendshift.io/api/badge/repositories/17293" alt="memvid%2Fmemvid | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
 </p>
-<!-- FLAGS:END -->
+
+<p align="center">
+  <strong>Memvid je jednosouborová paměťová vrstva pro AI agenty s okamžitým vyhledáváním a dlouhodobou pamětí.</strong><br/>
+  Trvalá, verzovaná a přenosná paměť, bez databází.
+</p>
 
 <!-- NAV:START -->
 <p align="center">
@@ -28,6 +22,8 @@
   <a href="https://docs.memvid.com">Docs</a>
   ·
   <a href="https://github.com/memvid/memvid/discussions">Discussions</a>
+  ·
+  <a href="docs/i18n/translation_hub.md">Translations</a>
 </p>
 <!-- NAV:END -->
 
@@ -44,16 +40,8 @@
   <a href="https://github.com/memvid/memvid/issues"><img src="https://img.shields.io/github/issues/memvid/memvid?style=flat-square&logo=github" alt="Issues" /></a>
   <a href="https://discord.gg/2mynS7fcK7"><img src="https://img.shields.io/discord/1442910055233224745?style=flat-square&logo=discord&label=discord" alt="Discord" /></a>
 </p>
-
-<p align="center">
-    <a href="https://trendshift.io/repositories/17293" target="_blank"><img src="https://trendshift.io/api/badge/repositories/17293" alt="memvid%2Fmemvid | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
-</p>
 <!-- BADGES:END -->
 
-<p align="center">
-  <strong>Memvid je jednosouborová paměťová vrstva pro AI agenty s okamžitým vyhledáváním a dlouhodobou pamětí.</strong><br/>
-  Trvalá, verzovaná a přenosná paměť, bez databází.
-</p>
 
 <h2 align="center">⭐️ Zanechte hvězdičku na podporu projektu ⭐️</h2>
 </p>

--- a/docs/i18n/README.es.md
+++ b/docs/i18n/README.es.md
@@ -2,22 +2,16 @@
 <img width="2000" height="524" alt="Social Cover (9)" src="https://github.com/user-attachments/assets/cf66f045-c8be-494b-b696-b8d7e4fb709c" />
 <!-- HEADER:END -->
 
-<!-- FLAGS:START -->
+<div style="height: 16px;"></div>
+
 <p align="center">
- <a href="../../README.md">🇺🇸 English</a>
- <a href="README.es.md">🇪🇸 Español</a>
- <a href="README.fr.md">🇫🇷 Français</a>
- <a href="README.so.md">🇸🇴 Soomaali</a>
- <a href="README.ar.md">🇸🇦 العربية</a>
- <a href="README.nl.md">🇧🇪/🇳🇱 Nederlands</a>
- <a href="README.hi.md">🇮🇳 हिन्दी</a>
- <a href="README.bn.md">🇧🇩 বাংলা</a>
- <a href="README.cs.md">🇨🇿 Čeština</a>
- <a href="README.ko.md">🇰🇷 한국어</a>
- <a href="README.ja.md">🇯🇵 日本語</a>
- <!-- Next Flag -->
+    <a href="https://trendshift.io/repositories/17293" target="_blank"><img src="https://trendshift.io/api/badge/repositories/17293" alt="memvid%2Fmemvid | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
 </p>
-<!-- FLAGS:END -->
+
+<p align="center">
+  <strong>Memvid es una capa de memoria de un solo archivo para agentes de IA, con recuperación instantánea y memoria a largo plazo.</strong><br/>
+  Memoria persistente, versionada y portable, sin bases de datos.
+</p>
 
 <!-- NAV:START -->
 <p align="center">
@@ -28,6 +22,8 @@
   <a href="https://docs.memvid.com">Docs</a>
   ·
   <a href="https://github.com/memvid/memvid/discussions">Discussions</a>
+  ·
+  <a href="docs/i18n/translation_hub.md">Translations</a>
 </p>
 <!-- NAV:END -->
 
@@ -44,16 +40,7 @@
   <a href="https://github.com/memvid/memvid/issues"><img src="https://img.shields.io/github/issues/memvid/memvid?style=flat-square&logo=github" alt="Issues" /></a>
   <a href="https://discord.gg/2mynS7fcK7"><img src="https://img.shields.io/discord/1442910055233224745?style=flat-square&logo=discord&label=discord" alt="Discord" /></a>
 </p>
-
-<p align="center">
-    <a href="https://trendshift.io/repositories/17293" target="_blank"><img src="https://trendshift.io/api/badge/repositories/17293" alt="memvid%2Fmemvid | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
-</p>
 <!-- BADGES:END -->
-
-<p align="center">
-  <strong>Memvid es una capa de memoria de un solo archivo para agentes de IA, con recuperación instantánea y memoria a largo plazo.</strong><br/>
-  Memoria persistente, versionada y portable, sin bases de datos.
-</p>
 
 <h2 align="center">⭐️ Deja una STAR para apoyar el proyecto ⭐️</h2>
 </p>

--- a/docs/i18n/README.fr.md
+++ b/docs/i18n/README.fr.md
@@ -2,22 +2,16 @@
 <img width="2000" height="524" alt="Social Cover (9)" src="https://github.com/user-attachments/assets/cf66f045-c8be-494b-b696-b8d7e4fb709c" />
 <!-- HEADER:END -->
 
-<!-- FLAGS:START -->
+<div style="height: 16px;"></div>
+
 <p align="center">
- <a href="../../README.md">🇺🇸 English</a>
- <a href="README.es.md">🇪🇸 Español</a>
- <a href="README.fr.md">🇫🇷 Français</a>
- <a href="README.so.md">🇸🇴 Soomaali</a>
- <a href="README.ar.md">🇸🇦 العربية</a>
- <a href="README.nl.md">🇧🇪/🇳🇱 Nederlands</a>
- <a href="README.hi.md">🇮🇳 हिन्दी</a>
- <a href="README.bn.md">🇧🇩 বাংলা</a>
- <a href="README.cs.md">🇨🇿 Čeština</a>
- <a href="README.ko.md">🇰🇷 한국어</a>
- <a href="README.ja.md">🇯🇵 日本語</a>
- <!-- Next Flag -->
+    <a href="https://trendshift.io/repositories/17293" target="_blank"><img src="https://trendshift.io/api/badge/repositories/17293" alt="memvid%2Fmemvid | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
 </p>
-<!-- FLAGS:END -->
+
+<p align="center">
+  <strong>Memvid est une couche mémoire à fichier unique pour agents IA, avec récupération instantanée et mémoire long terme.</strong><br/>
+  Mémoire persistante, versionnée et portable, sans bases de données.
+</p>
 
 <!-- NAV:START -->
 <p align="center">
@@ -28,6 +22,8 @@
   <a href="https://docs.memvid.com">Docs</a>
   ·
   <a href="https://github.com/memvid/memvid/discussions">Discussions</a>
+  ·
+  <a href="docs/i18n/translation_hub.md">Translations</a>
 </p>
 <!-- NAV:END -->
 
@@ -44,16 +40,7 @@
   <a href="https://github.com/memvid/memvid/issues"><img src="https://img.shields.io/github/issues/memvid/memvid?style=flat-square&logo=github" alt="Issues" /></a>
   <a href="https://discord.gg/2mynS7fcK7"><img src="https://img.shields.io/discord/1442910055233224745?style=flat-square&logo=discord&label=discord" alt="Discord" /></a>
 </p>
-
-<p align="center">
-    <a href="https://trendshift.io/repositories/17293" target="_blank"><img src="https://trendshift.io/api/badge/repositories/17293" alt="memvid%2Fmemvid | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
-</p>
 <!-- BADGES:END -->
-
-<p align="center">
-  <strong>Memvid est une couche mémoire à fichier unique pour agents IA, avec récupération instantanée et mémoire long terme.</strong><br/>
-  Mémoire persistante, versionnée et portable, sans bases de données.
-</p>
 
 <h2 align="center">⭐️ Laissez une STAR pour soutenir le projet ⭐️</h2>
 </p>

--- a/docs/i18n/README.hi.md
+++ b/docs/i18n/README.hi.md
@@ -2,22 +2,16 @@
 <img width="2000" height="524" alt="Social Cover (9)" src="https://github.com/user-attachments/assets/cf66f045-c8be-494b-b696-b8d7e4fb709c" />
 <!-- HEADER:END -->
 
-<!-- FLAGS:START -->
+<div style="height: 16px;"></div>
+
 <p align="center">
- <a href="../../README.md">🇺🇸 English</a>
- <a href="README.es.md">🇪🇸 Español</a>
- <a href="README.fr.md">🇫🇷 Français</a>
- <a href="README.so.md">🇸🇴 Soomaali</a>
- <a href="README.ar.md">🇸🇦 العربية</a>
- <a href="README.nl.md">🇧🇪/🇳🇱 Nederlands</a>
- <a href="README.hi.md">🇮🇳 हिन्दी</a>
- <a href="README.bn.md">🇧🇩 বাংলা</a>
- <a href="README.cs.md">🇨🇿 Čeština</a>
- <a href="README.ko.md">🇰🇷 한국어</a>
- <a href="README.ja.md">🇯🇵 日本語</a>
- <!-- Next Flag -->
+    <a href="https://trendshift.io/repositories/17293" target="_blank"><img src="https://trendshift.io/api/badge/repositories/17293" alt="memvid%2Fmemvid | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
 </p>
-<!-- FLAGS:END -->
+
+<p align="center">
+  <strong>मेमविड AI एजेंट के लिए एक सिंगल-फाइल मेमोरी लेयर है जिसमें तुरंत रिट्रीवल और लॉन्ग-टर्म मेमोरी होती है।</strong><br/>
+  बिना डेटाबेस के, स्थायी, वर्शन वाली और पोर्टेबल मेमोरी।
+</p>
 
 <!-- NAV:START -->
 <p align="center">
@@ -28,6 +22,8 @@
   <a href="https://docs.memvid.com">Docs</a>
   ·
   <a href="https://github.com/memvid/memvid/discussions">Discussions</a>
+  ·
+  <a href="docs/i18n/translation_hub.md">Translations</a>
 </p>
 <!-- NAV:END -->
 
@@ -44,16 +40,7 @@
   <a href="https://github.com/memvid/memvid/issues"><img src="https://img.shields.io/github/issues/memvid/memvid?style=flat-square&logo=github" alt="Issues" /></a>
   <a href="https://discord.gg/2mynS7fcK7"><img src="https://img.shields.io/discord/1442910055233224745?style=flat-square&logo=discord&label=discord" alt="Discord" /></a>
 </p>
-
-<p align="center">
-    <a href="https://trendshift.io/repositories/17293" target="_blank"><img src="https://trendshift.io/api/badge/repositories/17293" alt="memvid%2Fmemvid | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
-</p>
 <!-- BADGES:END -->
-
-<p align="center">
-  <strong>मेमविड AI एजेंट के लिए एक सिंगल-फाइल मेमोरी लेयर है जिसमें तुरंत रिट्रीवल और लॉन्ग-टर्म मेमोरी होती है।</strong><br/>
-  बिना डेटाबेस के, स्थायी, वर्शन वाली और पोर्टेबल मेमोरी।
-</p>
 
 <h2 align="center">⭐️ प्रोजेक्ट को सपोर्ट करने के लिए एक स्टार दें। ⭐️</h2>
 </p>

--- a/docs/i18n/README.ja.md
+++ b/docs/i18n/README.ja.md
@@ -2,22 +2,17 @@
 <img width="2000" height="524" alt="Social Cover (9)" src="https://github.com/user-attachments/assets/cf66f045-c8be-494b-b696-b8d7e4fb709c" />
 <!-- HEADER:END -->
 
-<!-- FLAGS:START -->
+<div style="height: 16px;"></div>
+
 <p align="center">
- <a href="../../README.md">🇺🇸 English</a>
- <a href="README.es.md">🇪🇸 Español</a>
- <a href="README.fr.md">🇫🇷 Français</a>
- <a href="README.so.md">🇸🇴 Soomaali</a>
- <a href="README.ar.md">🇸🇦 العربية</a>
- <a href="README.nl.md">🇧🇪/🇳🇱 Nederlands</a>
- <a href="README.hi.md">🇮🇳 हिन्दी</a>
- <a href="README.bn.md">🇧🇩 বাংলা</a>
- <a href="README.cs.md">🇨🇿 Čeština</a>
- <a href="README.ko.md">🇰🇷 한국어</a>
- <a href="README.ja.md">🇯🇵 日本語</a>
- <!-- Next Flag -->
+    <a href="https://trendshift.io/repositories/17293" target="_blank"><img src="https://trendshift.io/api/badge/repositories/17293" alt="memvid%2Fmemvid | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
 </p>
-<!-- FLAGS:END -->
+
+<p align="center">
+<strong>Memvidは、AIエージェントのための即時検索と長期記憶を備えた単一ファイル型メモリレイヤーです。</strong>
+</br>
+データベースを必要とせず、永続化、バージョン管理、ポータブル性を備えたメモリを実現します。
+</p>
 
 <!-- NAV:START -->
 <p align="center">
@@ -28,6 +23,8 @@
   <a href="https://docs.memvid.com">Docs</a>
   ·
   <a href="https://github.com/memvid/memvid/discussions">Discussions</a>
+  ·
+  <a href="docs/i18n/translation_hub.md">Translations</a>
 </p>
 <!-- NAV:END -->
 
@@ -44,17 +41,7 @@
   <a href="https://github.com/memvid/memvid/issues"><img src="https://img.shields.io/github/issues/memvid/memvid?style=flat-square&logo=github" alt="Issues" /></a>
   <a href="https://discord.gg/2mynS7fcK7"><img src="https://img.shields.io/discord/1442910055233224745?style=flat-square&logo=discord&label=discord" alt="Discord" /></a>
 </p>
-
-<p align="center">
-    <a href="https://trendshift.io/repositories/17293" target="_blank"><img src="https://trendshift.io/api/badge/repositories/17293" alt="memvid%2Fmemvid | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
-</p>
 <!-- BADGES:END -->
-
-<p align="center">
-<strong>Memvidは、AIエージェントのための即時検索と長期記憶を備えた単一ファイル型メモリレイヤーです。</strong>
-</br>
-データベースを必要とせず、永続化、バージョン管理、ポータブル性を備えたメモリを実現します。
-</p>
 
 <h2 align="center">⭐️ スターで応援お願いします ⭐️</h2>
 </p>

--- a/docs/i18n/README.ko.md
+++ b/docs/i18n/README.ko.md
@@ -2,22 +2,16 @@
 <img width="2000" height="524" alt="Social Cover (9)" src="https://github.com/user-attachments/assets/cf66f045-c8be-494b-b696-b8d7e4fb709c" />
 <!-- HEADER:END -->
 
-<!-- FLAGS:START -->
+<div style="height: 16px;"></div>
+
 <p align="center">
- <a href="../../README.md">🇺🇸 English</a>
- <a href="README.es.md">🇪🇸 Español</a>
- <a href="README.fr.md">🇫🇷 Français</a>
- <a href="README.so.md">🇸🇴 Soomaali</a>
- <a href="README.ar.md">🇸🇦 العربية</a>
- <a href="README.nl.md">🇧🇪/🇳🇱 Nederlands</a>
- <a href="README.hi.md">🇮🇳 हिन्दी</a>
- <a href="README.bn.md">🇧🇩 বাংলা</a>
- <a href="README.cs.md">🇨🇿 Čeština</a>
- <a href="README.ko.md">🇰🇷 한국어</a>
- <a href="README.ja.md">🇯🇵 日本語</a>
- <!-- Next Flag -->
+    <a href="https://trendshift.io/repositories/17293" target="_blank"><img src="https://trendshift.io/api/badge/repositories/17293" alt="memvid%2Fmemvid | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
 </p>
-<!-- FLAGS:END -->
+
+<p align="center">
+  <strong>Memvid는 AI 에이전트를 위한 단일 파일 메모리 레이어로, 인스턴스 검색 및 장기 메모리 기능을 제공합니다.</strong><br/>
+  데이터 베이스 없이 지속적이고, 버전 관리가 용이하며 여러 어플리케이션에 자유로운 적용이 가능합니다.
+</p>
 
 <!-- NAV:START -->
 <p align="center">
@@ -28,6 +22,8 @@
   <a href="https://docs.memvid.com">Docs</a>
   ·
   <a href="https://github.com/memvid/memvid/discussions">Discussions</a>
+  ·
+  <a href="docs/i18n/translation_hub.md">Translations</a>
 </p>
 <!-- NAV:END -->
 
@@ -44,16 +40,7 @@
   <a href="https://github.com/memvid/memvid/issues"><img src="https://img.shields.io/github/issues/memvid/memvid?style=flat-square&logo=github" alt="Issues" /></a>
   <a href="https://discord.gg/2mynS7fcK7"><img src="https://img.shields.io/discord/1442910055233224745?style=flat-square&logo=discord&label=discord" alt="Discord" /></a>
 </p>
-
-<p align="center">
-    <a href="https://trendshift.io/repositories/17293" target="_blank"><img src="https://trendshift.io/api/badge/repositories/17293" alt="memvid%2Fmemvid | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
-</p>
 <!-- BADGES:END -->
-
-<p align="center">
-  <strong>Memvid는 AI 에이전트를 위한 단일 파일 메모리 레이어로, 인스턴스 검색 및 장기 메모리 기능을 제공합니다.</strong><br/>
-  데이터 베이스 없이 지속적이고, 버전 관리가 용이하며 여러 어플리케이션에 자유로운 적용이 가능합니다.
-</p>
 
 <h2 align="center">⭐️ STAR로 이 프로젝트를 지원해주세요 ⭐️</h2>
 </p>

--- a/docs/i18n/README.nl.md
+++ b/docs/i18n/README.nl.md
@@ -2,22 +2,16 @@
 <img width="2000" height="524" alt="Social Cover (9)" src="https://github.com/user-attachments/assets/cf66f045-c8be-494b-b696-b8d7e4fb709c" />
 <!-- HEADER:END -->
 
-<!-- FLAGS:START -->
+<div style="height: 16px;"></div>
+
 <p align="center">
- <a href="../../README.md">🇺🇸 English</a>
- <a href="README.es.md">🇪🇸 Español</a>
- <a href="README.fr.md">🇫🇷 Français</a>
- <a href="README.so.md">🇸🇴 Soomaali</a>
- <a href="README.ar.md">🇸🇦 العربية</a>
- <a href="README.nl.md">🇧🇪/🇳🇱 Nederlands</a>
- <a href="README.hi.md">🇮🇳 हिन्दी</a>
- <a href="README.bn.md">🇧🇩 বাংলা</a>
- <a href="README.cs.md">🇨🇿 Čeština</a>
- <a href="README.ko.md">🇰🇷 한국어</a>
- <a href="README.ja.md">🇯🇵 日本語</a>
- <!-- Next Flag -->
+    <a href="https://trendshift.io/repositories/17293" target="_blank"><img src="https://trendshift.io/api/badge/repositories/17293" alt="memvid%2Fmemvid | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
 </p>
-<!-- FLAGS:END -->
+
+<p align="center">
+  <strong>Memvid is een geheugenlaag van één bestand voor AI-agenten met directe toegang en langetermijnsgeheugen.</strong><br/>
+  Volhardend en draagbaar geheugen met versiebeheer en zonder databases.
+</p>
 
 <!-- NAV:START -->
 <p align="center">
@@ -28,6 +22,8 @@
   <a href="https://docs.memvid.com">Docs</a>
   ·
   <a href="https://github.com/memvid/memvid/discussions">Discussions</a>
+  ·
+  <a href="docs/i18n/translation_hub.md">Translations</a>
 </p>
 <!-- NAV:END -->
 
@@ -44,16 +40,7 @@
   <a href="https://github.com/memvid/memvid/issues"><img src="https://img.shields.io/github/issues/memvid/memvid?style=flat-square&logo=github" alt="Issues" /></a>
   <a href="https://discord.gg/2mynS7fcK7"><img src="https://img.shields.io/discord/1442910055233224745?style=flat-square&logo=discord&label=discord" alt="Discord" /></a>
 </p>
-
-<p align="center">
-    <a href="https://trendshift.io/repositories/17293" target="_blank"><img src="https://trendshift.io/api/badge/repositories/17293" alt="memvid%2Fmemvid | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
-</p>
 <!-- BADGES:END -->
-
-<p align="center">
-  <strong>Memvid is een geheugenlaag van één bestand voor AI-agenten met directe toegang en langetermijnsgeheugen.</strong><br/>
-  Volhardend en draagbaar geheugen met versiebeheer en zonder databases.
-</p>
 
 <h2 align="center">⭐️ Laat een ster achter om het project te steunen ⭐️</h2>
 </p>

--- a/docs/i18n/README.so.md
+++ b/docs/i18n/README.so.md
@@ -2,24 +2,17 @@
 <img width="2000" height="524" alt="Social Cover (9)" src="https://github.com/user-attachments/assets/cf66f045-c8be-494b-b696-b8d7e4fb709c" />
 <!-- HEADER:END -->
 
-<!-- FLAGS:START -->
-<p align="center">
- <a href="../../README.md">🇺🇸 English</a>
- <a href="README.es.md">🇪🇸 Español</a>
- <a href="README.fr.md">🇫🇷 Français</a>
- <a href="README.so.md">🇸🇴 Soomaali</a>
- <a href="README.ar.md">🇸🇦 العربية</a>
- <a href="README.nl.md">🇧🇪/🇳🇱 Nederlands</a>
- <a href="README.hi.md">🇮🇳 हिन्दी</a>
- <a href="README.bn.md">🇧🇩 বাংলা</a>
- <a href="README.cs.md">🇨🇿 Čeština</a>
- <a href="README.ko.md">🇰🇷 한국어</a>
- <a href="README.ja.md">🇯🇵 日本語</a>
- <!-- Next Flag -->
-</p>
-<!-- FLAGS:END -->
+<div style="height: 16px;"></div>
 
-<!-- NAV:START -->
+<p align="center">
+    <a href="https://trendshift.io/repositories/17293" target="_blank"><img src="https://trendshift.io/api/badge/repositories/17293" alt="memvid%2Fmemvid | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
+</p>
+
+<p align="center">
+  <strong>Memvid waa nidaam xusuuseed oo hal fayl ah kaas oo loogu talagalay wakiillada AI (AI agents), lehna soo-celin degdeg ah iyo xusuus fog.</strong><br/>
+  Xusuus joogto ah, la raadin karo, lana qaadan karo, iyadoo aan loo baahnayn database-yo kale.
+</p><!-- NAV:START -->
+
 <p align="center">
   <a href="https://www.memvid.com">Website</a>
   ·
@@ -28,6 +21,8 @@
   <a href="https://docs.memvid.com">Docs</a>
   ·
   <a href="https://github.com/memvid/memvid/discussions">Discussions</a>
+  ·
+  <a href="docs/i18n/translation_hub.md">Translations</a>
 </p>
 <!-- NAV:END -->
 
@@ -44,16 +39,7 @@
   <a href="https://github.com/memvid/memvid/issues"><img src="https://img.shields.io/github/issues/memvid/memvid?style=flat-square&logo=github" alt="Issues" /></a>
   <a href="https://discord.gg/2mynS7fcK7"><img src="https://img.shields.io/discord/1442910055233224745?style=flat-square&logo=discord&label=discord" alt="Discord" /></a>
 </p>
-
-<p align="center">
-    <a href="https://trendshift.io/repositories/17293" target="_blank"><img src="https://trendshift.io/api/badge/repositories/17293" alt="memvid%2Fmemvid | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
-</p>
 <!-- BADGES:END -->
-
-<p align="center">
-  <strong>Memvid waa nidaam xusuuseed oo hal fayl ah kaas oo loogu talagalay wakiillada AI (AI agents), lehna soo-celin degdeg ah iyo xusuus fog.</strong><br/>
-  Xusuus joogto ah, la raadin karo, lana qaadan karo, iyadoo aan loo baahnayn database-yo kale.
-</p>
 
 <h2 align="center">⭐️ Noo saar STAR si aad mashruuca u taageerto ⭐️</h2>
 

--- a/docs/i18n/README.zh-CN.md
+++ b/docs/i18n/README.zh-CN.md
@@ -8,7 +8,6 @@
 <p align="center">
     <a href="https://trendshift.io/repositories/17293" target="_blank"><img src="https://trendshift.io/api/badge/repositories/17293" alt="memvid%2Fmemvid | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
 </p>
-<!-- BADGES:END -->
 
 <p align="center">
   <strong>Memvid 是专为 AI 智能体设计的单文件记忆层，具备即时检索和长期记忆能力。</strong><br/>
@@ -24,6 +23,8 @@
   <a href="https://docs.memvid.com">文档</a>
   ·
   <a href="https://github.com/memvid/memvid/discussions">讨论区</a>
+  ·
+  <a href="docs/i18n/translation_hub.md">Translations</a>
 </p>
 <!-- NAV:END -->
 
@@ -40,8 +41,7 @@
   <a href="https://github.com/memvid/memvid/issues"><img src="https://img.shields.io/github/issues/memvid/memvid?style=flat-square&logo=github" alt="Issues" /></a>
   <a href="https://discord.gg/2mynS7fcK7"><img src="https://img.shields.io/discord/1442910055233224745?style=flat-square&logo=discord&label=discord" alt="Discord" /></a>
 </p>
-
-
+<!-- BADGES:END -->
 
 <h2 align="center">⭐️ 给项目点个星标支持我们 ⭐️</h2>
 

--- a/docs/i18n/translation_hub.md
+++ b/docs/i18n/translation_hub.md
@@ -1,0 +1,64 @@
+<!-- HEADER:START -->
+<img width="2000" height="524" alt="Social Cover (9)"
+     src="https://github.com/user-attachments/assets/cf66f045-c8be-494b-b696-b8d7e4fb709c" />
+<!-- HEADER:END -->
+
+<div style="height: 16px;"></div>
+
+<p align="center">
+    <a href="https://trendshift.io/repositories/17293" target="_blank"><img src="https://trendshift.io/api/badge/repositories/17293" alt="memvid%2Fmemvid | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
+</p>
+<!-- BADGES:END -->
+
+<p align="center">
+  <strong>Memvid is a single-file memory layer for AI agents with instant retrieval and long-term memory.</strong><br/>
+  Persistent, versioned, and portable memory, without databases.
+</p>
+
+<!-- NAV:START -->
+<p align="center">
+  <a href="https://www.memvid.com">Website</a>
+  ·
+  <a href="https://sandbox.memvid.com">Try Sandbox</a>
+  ·
+  <a href="https://docs.memvid.com">Docs</a>
+  ·
+  <a href="https://github.com/memvid/memvid/discussions">Discussions</a>
+  .
+  <a href="docs/i18n/translation_hub.md">Translations</a>
+</p>
+<!-- NAV:END -->
+
+<!-- BADGES:START -->
+<p align="center">
+  <a href="https://crates.io/crates/memvid-core"><img src="https://img.shields.io/crates/v/memvid-core?style=flat-square&logo=rust" alt="Crates.io" /></a>
+  <a href="https://docs.rs/memvid-core"><img src="https://img.shields.io/docsrs/memvid-core?style=flat-square&logo=docs.rs" alt="docs.rs" /></a>
+  <a href="https://github.com/memvid/memvid/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="License" /></a>
+</p>
+
+<p align="center">
+  <a href="https://github.com/memvid/memvid/stargazers"><img src="https://img.shields.io/github/stars/memvid/memvid?style=flat-square&logo=github" alt="Stars" /></a>
+  <a href="https://github.com/memvid/memvid/network/members"><img src="https://img.shields.io/github/forks/memvid/memvid?style=flat-square&logo=github" alt="Forks" /></a>
+  <a href="https://github.com/memvid/memvid/issues"><img src="https://img.shields.io/github/issues/memvid/memvid?style=flat-square&logo=github" alt="Issues" /></a>
+  <a href="https://discord.gg/2mynS7fcK7"><img src="https://img.shields.io/discord/1442910055233224745?style=flat-square&logo=discord&label=discord" alt="Discord" /></a>
+</p>
+
+## Languages
+
+<!-- FLAGS:START -->
+<p align="center" style="font-size: 24px;">
+  <a href="../../README.md">🇺🇸 English</a><br>
+  <a href="README.es.md">🇪🇸 Español</a><br>
+  <a href="README.fr.md">🇫🇷 Français</a><br>
+  <a href="README.so.md">🇸🇴 Soomaali</a><br>
+  <a href="README.ar.md">🇸🇦 العربية</a><br>
+  <a href="README.nl.md">🇧🇪/🇳🇱 Nederlands</a><br>
+  <a href="README.hi.md">🇮🇳 हिन्दी</a><br>
+  <a href="README.bn.md">🇧🇩 বাংলা</a><br>
+  <a href="README.cs.md">🇨🇿 Čeština</a><br>
+  <a href="README.ko.md">🇰🇷 한국어</a><br>
+  <a href="README.ja.md">🇯🇵 日本語</a><br>
+  <a href="README.zh-CN.md">🇨🇳 简体中文</a>
+  <!-- Next Flag -->
+</p>
+<!-- FLAGS:END -->


### PR DESCRIPTION
## Description
* Added "Translations" navigation button and translation hub
* Standardized the start of the README files of all languages

## Related Issue
Suggestion for the issue discussed in #144 

## Type of Change
- [x] Documentation update

## Changes Made
- Added the button
- Switched stuff around, so it has the same order in all languages
- Made a hub to choose the language of the README

## Documentation
- [x] I have updated relevant documentation
- [ ] I have added doc comments for new public APIs
- [ ] CHANGELOG.md has been updated (if applicable)

## Additional Notes
Some README files have the hyperlinks translated. As I am not a speaker of those languages, it might be better if the translators of these languages would translate my "Translations" navigation button.

Any way of making the hub a bit more appealable?
This is a mere suggestion, I'm open for feedback or denial. 
