### PR TITLE
fix: reclaim disk space in vacuum()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ed25519 signatures for authenticity
 - Optional AES-256-GCM encryption
 
+### Fixed
+- `vacuum()` now reclaims disk space from deleted or superseded frames. It
+  previously rebuilt the indexes at a smaller size but never truncated the file
+  (a monotonic `footer_offset` clamp), so it freed nothing. It now also re-emits
+  the sketch track and resets the WAL after compaction, leaving the file
+  consistent (deep `verify` passes). Space is not reclaimed for files containing
+  a replay segment, whose bytes a rebuild cannot relocate.
+
 ### Security
 - Embedded WAL prevents data corruption
 - Atomic commits ensure consistency

--- a/src/memvid/doctor.rs
+++ b/src/memvid/doctor.rs
@@ -1144,7 +1144,7 @@ impl DoctorExecutor {
                     // This ensures a clean slate even if doctor's own operations had WAL issues
                     if let Some(ref mut held) = mem {
                         doctor_log!("doctor: performing final WAL cleanup before verification");
-                        if let Err(err) = Self::reset_wal(held) {
+                        if let Err(err) = held.reset_wal() {
                             doctor_log!("doctor: WARNING - final WAL cleanup failed: {}", err);
                             additional_findings.push(DoctorFinding::warning(
                                 DoctorFindingCode::InternalError,
@@ -1163,7 +1163,7 @@ impl DoctorExecutor {
                         && Self::verification_is_wal_only_failure(&report)
                     {
                         if let Ok(mut reopen) = Memvid::try_open(&path) {
-                            let _ = Self::reset_wal(&mut reopen);
+                            let _ = reopen.reset_wal();
                         }
                         report = Self::run_verification(&path)?;
                         if Self::verification_is_wal_only_failure(&report) {
@@ -1475,7 +1475,7 @@ impl DoctorExecutor {
         // and could potentially corrupt the freshly written footer_offset.
 
         // Reset WAL while preserving the correct footer_offset
-        Self::reset_wal(mem)?;
+        mem.reset_wal()?;
 
         // Verify footer_offset wasn't corrupted
         if mem.header.footer_offset != footer_offset_after_rebuild {
@@ -1497,49 +1497,6 @@ impl DoctorExecutor {
             status: DoctorActionStatus::Executed,
             detail: Some("indexes rebuilt".into()),
         })
-    }
-
-    fn reset_wal(mem: &mut Memvid) -> Result<()> {
-        doctor_log!(
-            "doctor: reset_wal - zeroing {} bytes at offset {}",
-            mem.header.wal_size,
-            mem.header.wal_offset
-        );
-        let mut remaining = mem.header.wal_size;
-        let mut offset = mem.header.wal_offset;
-        let chunk_size = (remaining.min(4096) as usize).max(1);
-        let zeros = vec![0u8; chunk_size];
-        while remaining > 0 {
-            let write_len = usize::try_from(remaining.min(zeros.len() as u64)).unwrap_or(0);
-            mem.file.seek(SeekFrom::Start(offset))?;
-            mem.file.write_all(&zeros[..write_len])?;
-            remaining -= write_len as u64;
-            offset += write_len as u64;
-        }
-        mem.file.sync_all()?;
-        doctor_log!("doctor: reset_wal - WAL region zeroed and synced");
-
-        // CRITICAL: Update and persist header BEFORE reopening WAL
-        // EmbeddedWal::open will read the header, so it must have the correct values
-        mem.header.wal_checkpoint_pos = 0;
-        mem.header.wal_sequence = 0;
-        crate::persist_header(&mut mem.file, &mem.header)?;
-        mem.file.sync_all()?;
-        doctor_log!("doctor: reset_wal - header updated with wal_sequence=0, wal_checkpoint_pos=0");
-
-        // Now reopen the WAL with the clean state
-        mem.wal = EmbeddedWal::open(&mem.file, &mem.header)?;
-        doctor_log!("doctor: reset_wal - WAL reopened successfully");
-
-        // CRITICAL: Clear dirty flag to prevent Drop from calling commit()
-        // Drop handler will call commit() if dirty=true, which would corrupt the WAL we just cleaned
-        mem.dirty = false;
-        #[cfg(feature = "lex")]
-        {
-            mem.tantivy_dirty = false;
-        }
-        doctor_log!("doctor: reset_wal - cleared dirty flags");
-        Ok(())
     }
 
     fn run_verification(path: &Path) -> Result<VerificationReport> {

--- a/src/memvid/mutation.rs
+++ b/src/memvid/mutation.rs
@@ -959,29 +959,8 @@ impl Memvid {
             self.flush_tantivy()?;
         }
 
-        // Persist CLIP index if it has embeddings and wasn't already persisted by rebuild_indexes
-        if !indexes_rebuilt && self.clip_enabled {
-            if let Some(ref clip_index) = self.clip_index {
-                if !clip_index.is_empty() {
-                    self.persist_clip_index()?;
-                }
-            }
-        }
-
-        // Persist memories track if it has cards and wasn't already persisted by rebuild_indexes
-        if !indexes_rebuilt && self.memories_track.card_count() > 0 {
-            self.persist_memories_track()?;
-        }
-
-        // Persist logic mesh if it has nodes and wasn't already persisted by rebuild_indexes
-        if !indexes_rebuilt && !self.logic_mesh.is_empty() {
-            self.persist_logic_mesh()?;
-        }
-
-        // Persist sketch track if it has entries
-        if !self.sketch_track.is_empty() {
-            self.persist_sketch_track()?;
-        }
+        // Persist the sections that rebuild_indexes does not itself emit.
+        self.persist_deferred_sections(indexes_rebuilt)?;
 
         // flush_tantivy() and rebuild_indexes() have already set footer_offset correctly.
         // DO NOT overwrite it with catalog_data_end() as that would include orphaned segments.
@@ -2582,6 +2561,39 @@ impl Memvid {
         Ok(())
     }
 
+    /// Persist the sections that a rebuild does not itself emit, so a rebuilt or
+    /// compacted file carries every section at its current offset.
+    ///
+    /// `rebuild_indexes` writes the time/lex/vec indexes and — when it runs — the
+    /// clip, memories, and logic-mesh sections, but it never emits the sketch
+    /// track. Callers pass `indexes_rebuilt = true` when `rebuild_indexes` has just
+    /// run (so only the sketch track is outstanding) and `false` otherwise (so the
+    /// clip/memories/mesh sections are persisted here too). Every caller must
+    /// follow this with `rewrite_toc_footer` and a header persist.
+    fn persist_deferred_sections(&mut self, indexes_rebuilt: bool) -> Result<()> {
+        // clip/memories/mesh are emitted by rebuild_indexes; only re-persist them
+        // here when it did not run.
+        if !indexes_rebuilt && self.clip_enabled {
+            if let Some(ref clip_index) = self.clip_index {
+                if !clip_index.is_empty() {
+                    self.persist_clip_index()?;
+                }
+            }
+        }
+        if !indexes_rebuilt && self.memories_track.card_count() > 0 {
+            self.persist_memories_track()?;
+        }
+        if !indexes_rebuilt && !self.logic_mesh.is_empty() {
+            self.persist_logic_mesh()?;
+        }
+        // The sketch track is never emitted by rebuild_indexes, so it is always
+        // persisted here when present.
+        if !self.sketch_track.is_empty() {
+            self.persist_sketch_track()?;
+        }
+        Ok(())
+    }
+
     #[cfg(feature = "lex")]
     fn apply_lex_wal(&mut self, batch: LexWalBatch) -> Result<()> {
         let LexWalBatch {
@@ -3010,6 +3022,21 @@ impl Memvid {
 }
 
 impl Memvid {
+    /// Compact the file in place, reclaiming space held by deleted or superseded
+    /// frames.
+    ///
+    /// Active-frame payloads are repacked contiguously and all index sections are
+    /// rebuilt from scratch, dropping data that belonged to inactive frames; the
+    /// file is then truncated to its new size and left with a clean WAL.
+    ///
+    /// Space is only reclaimed when the file has no replay segment — a rebuild
+    /// cannot relocate replay bytes, so in that case the payloads are still
+    /// repacked but the file is not shrunk, keeping the replay manifest valid.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if reading a payload, rebuilding an index, or writing to
+    /// the file fails.
     pub fn vacuum(&mut self) -> Result<()> {
         self.commit()?;
 
@@ -3073,8 +3100,85 @@ impl Memvid {
             self.tantivy_dirty = false;
         }
 
+        // Reclaim the space freed by compaction. `rebuild_indexes` clamps
+        // `footer_offset` monotonically (to protect replay segments written above
+        // the index region), so without resetting it here the rebuilt — smaller —
+        // indexes get written but the file is never truncated, reclaiming nothing.
+        // Resetting is only safe when nothing above the payload boundary survives
+        // the rebuild by reference. `rebuild_indexes` re-emits every index/track it
+        // owns and `persist_deferred_sections` re-emits the sketch track, but the
+        // replay segment and the temporal track are neither re-emitted nor
+        // relocatable here. So when either is present, keep the clamp and forgo
+        // reclaim rather than truncate the file below a section whose manifest
+        // still points into the old (now-reclaimed) region.
+        //
+        // In that branch the payloads are still repacked low, but
+        // `footer_offset`/`cached_payload_end` are intentionally left at the
+        // pre-compaction positions so the rebuilt indexes are written where they
+        // already were — provably below the pinned sections — at the cost of a
+        // benign unused gap. Skipping the repack entirely for these files would
+        // avoid that gap and is a possible follow-up.
+        if self.toc.replay_manifest.is_none() && self.toc.temporal_track.is_none() {
+            self.cached_payload_end = self.data_end;
+            self.header.footer_offset = self.data_end;
+        }
+
         self.rebuild_indexes(&[], &[])?;
+
+        // `rebuild_indexes` re-emits every section except the sketch track, so
+        // persist the deferred sections and re-finalize the TOC. Without this the
+        // footer reset above would truncate the sketch track out from under its
+        // still-live manifest.
+        self.persist_deferred_sections(true)?;
+        self.rewrite_toc_footer()?;
+        self.header.toc_checksum = self.toc.toc_checksum;
+        // Persist the header here so the new footer_offset/toc_checksum reach disk
+        // as an explicit step, not as a side effect of reset_wal's own header write.
+        crate::persist_header(&mut self.file, &self.header)?;
+
+        // A full rebuild materialises all state directly into the TOC and data
+        // region, so any WAL entry left after it is stale. Discard the WAL so the
+        // file reopens with a clean, consistent log (matching the doctor path).
+        self.reset_wal()?;
+        Ok(())
+    }
+
+    /// Zero the embedded WAL region and reset its checkpoint state.
+    ///
+    /// After a full rebuild ([`vacuum`](Self::vacuum) or a doctor repair) the TOC
+    /// and data region are the authoritative record of every frame, so any residual
+    /// WAL entry is stale. This discards the WAL rather than replaying
+    /// already-persisted records, leaving the file with a clean log.
+    pub(crate) fn reset_wal(&mut self) -> Result<()> {
+        let zeros = [0u8; 4096];
+        let mut remaining = self.header.wal_size;
+        let mut offset = self.header.wal_offset;
+        while remaining > 0 {
+            let chunk = remaining.min(4096);
+            let write_len = usize::try_from(chunk).unwrap_or(zeros.len());
+            self.file.seek(SeekFrom::Start(offset))?;
+            self.file.write_all(&zeros[..write_len])?;
+            remaining -= chunk;
+            offset += chunk;
+        }
         self.file.sync_all()?;
+
+        // Update and persist the header BEFORE reopening the WAL: `EmbeddedWal::open`
+        // reads the header, so it must already reflect the cleared state.
+        self.header.wal_checkpoint_pos = 0;
+        self.header.wal_sequence = 0;
+        crate::persist_header(&mut self.file, &self.header)?;
+        self.file.sync_all()?;
+
+        self.wal = EmbeddedWal::open(&self.file, &self.header)?;
+
+        // Clear dirty flags so the Drop handler does not re-commit into the WAL we
+        // just cleared.
+        self.dirty = false;
+        #[cfg(feature = "lex")]
+        {
+            self.tantivy_dirty = false;
+        }
         Ok(())
     }
 
@@ -4175,5 +4279,89 @@ pub(crate) fn merge_unique(target: &mut Vec<String>, additions: Vec<String>) {
         if seen.insert(candidate.clone()) {
             target.push(candidate);
         }
+    }
+}
+
+#[cfg(test)]
+mod temporal_track_vacuum {
+    use super::*;
+    use crate::types::TemporalTrackManifest;
+    use tempfile::TempDir;
+
+    /// Regression: in a default (non-`temporal_track`) build, vacuum must not
+    /// corrupt a `temporal_track` section written by a temporal-enabled build.
+    /// The reclaim guard skips shrinking when a temporal (or replay) section is
+    /// present, so the manifest stays valid (its bytes remain below the footer)
+    /// rather than being truncated into the rewritten TOC region.
+    ///
+    /// White-box: a default build has no public API to create a temporal section,
+    /// so the manifest is injected directly to simulate a cross-build file.
+    #[test]
+    fn vacuum_preserves_temporal_track_manifest() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("t.mv2");
+
+        {
+            let mut mem = Memvid::create(&path).unwrap();
+            for i in 0..100 {
+                let opts = PutOptions {
+                    uri: Some(format!("mv2://doc/{i}")),
+                    title: Some(format!("Document {i}")),
+                    ..Default::default()
+                };
+                mem.put_bytes_with_options(
+                    format!("content for document number {i} with some filler text").as_bytes(),
+                    opts,
+                )
+                .unwrap();
+            }
+            mem.commit().unwrap();
+        }
+
+        let mut mem = Memvid::open(&path).unwrap();
+        for i in (0..100).step_by(2) {
+            let id = mem.frame_by_uri(&format!("mv2://doc/{i}")).unwrap().id;
+            mem.delete_frame(id).unwrap();
+        }
+        mem.commit().unwrap();
+
+        // Simulate a temporal section written by a temporal-enabled build: a
+        // manifest pointing into the current above-payload region. No real bytes
+        // needed — a default build never reads it; vacuum only carries the manifest
+        // through the TOC.
+        let old_footer = mem.header.footer_offset;
+        mem.toc.temporal_track = Some(TemporalTrackManifest {
+            bytes_offset: old_footer.saturating_sub(64),
+            bytes_length: 64,
+            entry_count: 1,
+            anchor_count: 1,
+            checksum: [0u8; 32],
+            flags: 0,
+        });
+
+        mem.vacuum().unwrap();
+        drop(mem);
+
+        let mem = Memvid::open(&path).unwrap();
+        let file_len = std::fs::metadata(&path).unwrap().len();
+        let tm = mem
+            .toc
+            .temporal_track
+            .clone()
+            .expect("temporal_track manifest should survive vacuum");
+
+        // Correct invariant: an above-payload section must live in the data region,
+        // strictly below the footer (= TOC start). If the offset is >= footer, the
+        // manifest now points into the rewritten TOC → a temporal reader would read
+        // TOC bytes as temporal data (corruption).
+        assert!(
+            tm.bytes_offset + tm.bytes_length <= mem.header.footer_offset,
+            "temporal_track points into the TOC region after vacuum: offset={} len={} footer_offset={} file_len={} old_footer={}",
+            tm.bytes_offset,
+            tm.bytes_length,
+            mem.header.footer_offset,
+            file_len,
+            old_footer
+        );
     }
 }

--- a/src/memvid/mutation.rs
+++ b/src/memvid/mutation.rs
@@ -3079,11 +3079,6 @@ impl Memvid {
         self.toc.segment_catalog.lex_segments.clear();
         self.toc.segment_catalog.vec_segments.clear();
         self.toc.segment_catalog.time_segments.clear();
-        #[cfg(feature = "temporal_track")]
-        {
-            self.toc.temporal_track = None;
-            self.toc.segment_catalog.temporal_segments.clear();
-        }
         #[cfg(feature = "lex")]
         {
             self.toc.segment_catalog.tantivy_segments.clear();
@@ -3123,7 +3118,25 @@ impl Memvid {
             self.header.footer_offset = self.data_end;
         }
 
+        // In a `temporal_track` build, `rebuild_indexes` clears the temporal
+        // manifest and — with the empty delta below — re-emits nothing, so
+        // vacuum must carry the section through by hand, exactly as a
+        // default build does. The section's bytes are pinned below the
+        // footer by the reclaim guard above, and vacuum never renumbers
+        // frames, so the saved manifest and segment descriptors stay valid.
+        #[cfg(feature = "temporal_track")]
+        let preserved_temporal = (
+            self.toc.temporal_track.clone(),
+            self.toc.segment_catalog.temporal_segments.clone(),
+        );
+
         self.rebuild_indexes(&[], &[])?;
+
+        #[cfg(feature = "temporal_track")]
+        {
+            self.toc.temporal_track = preserved_temporal.0;
+            self.toc.segment_catalog.temporal_segments = preserved_temporal.1;
+        }
 
         // `rebuild_indexes` re-emits every section except the sketch track, so
         // persist the deferred sections and re-finalize the TOC. Without this the

--- a/tests/mutation.rs
+++ b/tests/mutation.rs
@@ -3,7 +3,8 @@
 
 use memvid_core::{
     EmbeddingIdentitySummary, MEMVID_EMBEDDING_MODEL_KEY, MEMVID_EMBEDDING_PROVIDER_KEY, Memvid,
-    MemvidError, PutOptions, TimelineQuery, constants::HEADER_SIZE, io::header::HeaderCodec,
+    MemvidError, PutOptions, TimelineQuery, VerificationStatus, constants::HEADER_SIZE,
+    io::header::HeaderCodec,
 };
 use std::fs::File;
 use std::io::Read;
@@ -536,5 +537,198 @@ fn commit_per_put_survives_wal_growth() {
         reopened.stats().unwrap().frame_count,
         frames_written,
         "all frames should be durable after WAL growth"
+    );
+}
+
+/// Vacuum must reclaim disk space left behind by deleted (superseded) frames.
+///
+/// Regression test for a `footer_offset` clamp in `rebuild_indexes`: `vacuum()`
+/// rebuilt the indexes at a smaller size but never truncated the file, so it
+/// reclaimed nothing.
+#[test]
+fn vacuum_reclaims_space_from_deleted_frames() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.mv2");
+
+    // Insert enough sizeable documents (each kept under the chunking threshold)
+    // that deleted payload + index space dominates fixed overhead (header, WAL,
+    // TOC).
+    let mut body_lens: Vec<usize> = Vec::new();
+    {
+        let mut mem = Memvid::create(&path).unwrap();
+        for i in 0..200 {
+            let body =
+                format!("document {i}: the quick brown fox jumps over the lazy dog. ").repeat(25);
+            let opts = PutOptions {
+                uri: Some(format!("mv2://doc/{i}")),
+                title: Some(format!("Document {i}")),
+                ..Default::default()
+            };
+            mem.put_bytes_with_options(body.as_bytes(), opts).unwrap();
+            body_lens.push(body.len());
+        }
+        mem.commit().unwrap();
+    }
+
+    // Delete every other document, measure the file, then compact.
+    let size_before;
+    let mut deleted_bytes = 0usize;
+    {
+        let mut mem = Memvid::open(&path).unwrap();
+        for i in (0..200).step_by(2) {
+            let frame_id = mem.frame_by_uri(&format!("mv2://doc/{i}")).unwrap().id;
+            mem.delete_frame(frame_id).unwrap();
+            deleted_bytes += body_lens[i];
+        }
+        mem.commit().unwrap();
+        size_before = std::fs::metadata(&path).unwrap().len();
+
+        mem.vacuum().unwrap();
+    }
+
+    let size_after = std::fs::metadata(&path).unwrap().len();
+    let reclaimed = size_before.saturating_sub(size_after);
+    let expected_min = u64::try_from(deleted_bytes / 2).unwrap();
+
+    // Post-fix, vacuum reclaims at least the deleted payload bytes (plus their
+    // index entries). Pre-fix it reclaims ~nothing, so this assertion fails.
+    assert!(
+        reclaimed >= expected_min,
+        "vacuum reclaimed {reclaimed} bytes; expected >= {expected_min} \
+         (deleted {deleted_bytes} payload bytes; before={size_before}, after={size_after})"
+    );
+
+    // Reclaiming must not corrupt any section. Deep verify covers the time/lex/vec
+    // indexes and the WAL, but NOT the sketch track — that is asserted explicitly
+    // below.
+    let report = Memvid::verify(&path, true).unwrap();
+    assert_eq!(
+        report.overall_status,
+        VerificationStatus::Passed,
+        "vacuumed file should verify as healthy; checks: {:?}",
+        report.checks
+    );
+
+    // The sketch track is the one section rebuild_indexes omits; confirm it
+    // survived the compaction rather than being truncated under a stale manifest.
+    let mem = Memvid::open_read_only(&path).unwrap();
+    assert!(mem.has_sketches(), "sketch track must survive vacuum");
+    assert!(
+        mem.sketch_stats().entry_count > 0,
+        "sketch track should be non-empty after vacuum"
+    );
+}
+
+/// Vacuum must preserve every active frame and leave the file consistent.
+#[test]
+fn vacuum_preserves_active_frames() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.mv2");
+
+    {
+        let mut mem = Memvid::create(&path).unwrap();
+        for i in 0..50 {
+            let opts = PutOptions {
+                uri: Some(format!("mv2://doc/{i}")),
+                title: Some(format!("Document {i}")),
+                ..Default::default()
+            };
+            mem.put_bytes_with_options(format!("content for document {i}").as_bytes(), opts)
+                .unwrap();
+        }
+        mem.commit().unwrap();
+    }
+
+    // Delete the even-indexed documents (resolving FrameId by URI), then compact.
+    {
+        let mut mem = Memvid::open(&path).unwrap();
+        for i in (0..50).step_by(2) {
+            let frame_id = mem.frame_by_uri(&format!("mv2://doc/{i}")).unwrap().id;
+            mem.delete_frame(frame_id).unwrap();
+        }
+        mem.commit().unwrap();
+        mem.vacuum().unwrap();
+    }
+
+    // The compacted file verifies as healthy — a deep check includes a clean WAL,
+    // which vacuum must leave behind.
+    let report = Memvid::verify(&path, true).unwrap();
+    assert_eq!(
+        report.overall_status,
+        VerificationStatus::Passed,
+        "vacuumed file should verify as healthy; checks: {:?}",
+        report.checks
+    );
+
+    // Every surviving (odd-indexed) frame still resolves with its metadata.
+    let mem = Memvid::open_read_only(&path).unwrap();
+    for i in (1..50).step_by(2) {
+        let frame = mem.frame_by_uri(&format!("mv2://doc/{i}")).unwrap();
+        assert_eq!(frame.title, Some(format!("Document {i}")));
+    }
+}
+
+/// Vacuum must preserve the vector index — a path the lex-only tests never
+/// exercise. Asserts the vec index both verifies AND answers a real vector query
+/// after compaction (decode alone is insufficient).
+#[cfg(feature = "vec")]
+#[test]
+fn vacuum_preserves_vector_index() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.mv2");
+
+    const N: usize = 32;
+    let embedding = |i: usize| {
+        let mut v = vec![0.0f32; N];
+        v[i] = 1.0;
+        v
+    };
+
+    {
+        let mut mem = Memvid::create(&path).unwrap();
+        for i in 0..N {
+            let opts = PutOptions {
+                uri: Some(format!("mv2://doc/{i}")),
+                title: Some(format!("Document {i}")),
+                ..Default::default()
+            };
+            mem.put_with_embedding_and_options(
+                format!("content for document {i}").as_bytes(),
+                embedding(i),
+                opts,
+            )
+            .unwrap();
+        }
+        mem.commit().unwrap();
+    }
+
+    // Delete even-indexed docs, then compact.
+    {
+        let mut mem = Memvid::open(&path).unwrap();
+        for i in (0..N).step_by(2) {
+            let id = mem.frame_by_uri(&format!("mv2://doc/{i}")).unwrap().id;
+            mem.delete_frame(id).unwrap();
+        }
+        mem.commit().unwrap();
+        mem.vacuum().unwrap();
+    }
+
+    let report = Memvid::verify(&path, true).unwrap();
+    assert_eq!(
+        report.overall_status,
+        VerificationStatus::Passed,
+        "vacuumed file should verify as healthy; checks: {:?}",
+        report.checks
+    );
+
+    // A vector query for a survivor's own embedding must return that survivor —
+    // proves the rebuilt vec index maps to the relocated frames, not just decodes.
+    let mut mem = Memvid::open(&path).unwrap();
+    let survivor_id = mem.frame_by_uri("mv2://doc/3").unwrap().id;
+    let hits = mem.search_vec(&embedding(3), 1).unwrap();
+    assert_eq!(
+        hits.first().map(|h| h.frame_id),
+        Some(survivor_id),
+        "vector search should return the surviving frame after vacuum; hits={hits:?}"
     );
 }


### PR DESCRIPTION
## Description

`rebuild_indexes` clamps `footer_offset` monotonically (to protect replay segments) and `vacuum `never reset it, so compaction rebuilt smaller indexes but never truncated the file.

Reset `footer_offset` to the payload boundary before the rebuild, guarded on the absence of any section a rebuild can't relocate (replay or temporal). `rebuild_indexes` omits the sketch track, so re-emit deferred sections after it; extract `reset_wal` (shared with the doctor) so vacuum also leaves a clean WAL.

Tests: reclaim, post-vacuum integrity (incl. sketch track), temporal-section preservation, and vec-index survival (verify + real vector query after compaction).

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made
- extract `reset_wal` for reuse outside of doctor
- extract persistence shared between rebuilding indices + vacuuming
- introduce tests verifying existing bug alongside regression test

## Testing
- [x] I have added tests that prove my fix/feature works
- [x] All existing tests pass (`cargo test`)
- [x] I have tested on my local machine
- [x] I verified `vacuum` works as expected on a large local index

## Documentation
- [x] I have updated relevant documentation
- [x] I have added doc comments for new public APIs
- [x] CHANGELOG.md has been updated (if applicable)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings
- [x] I have run `cargo clippy` and addressed any issues
- [x] I have run `cargo fmt` to format my code

## Additional Notes

When making changes via cargo, the `Cargo.lock` file version changed to the latest version (`2.0.140`); I did not commit this change.
