### PR TITLE
fix: batch-mode WAL replay bounds and skip_sync; add shrink_wal_to

### DIFF
--- a/src/io/wal.rs
+++ b/src/io/wal.rs
@@ -16,6 +16,7 @@ pub struct WalStats {
     pub pending_bytes: u64,
     pub appends_since_checkpoint: u64,
     pub sequence: u64,
+    pub skip_sync: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -211,6 +212,7 @@ impl EmbeddedWal {
             pending_bytes: self.pending_bytes,
             appends_since_checkpoint: self.appends_since_checkpoint,
             sequence: self.sequence,
+            skip_sync: self.skip_sync,
         }
     }
 

--- a/src/io/wal.rs
+++ b/src/io/wal.rs
@@ -41,6 +41,17 @@ pub struct EmbeddedWal {
 }
 
 impl EmbeddedWal {
+    /// Mark a fully-checkpointed region as empty by writing a zero
+    /// sentinel at its start. Required after the region is resized in
+    /// place: stale record bytes from the previous geometry remain in
+    /// the retained head, and a record straddling the new boundary
+    /// makes the next open's scan misparse them as corruption.
+    pub fn write_empty_sentinel(file: &mut File, header: &Header) -> Result<()> {
+        file.seek(SeekFrom::Start(header.wal_offset))?;
+        file.write_all(&[0u8; ENTRY_HEADER_SIZE])?;
+        Ok(())
+    }
+
     pub fn open(file: &File, header: &Header) -> Result<Self> {
         Self::open_internal(file, header, false)
     }

--- a/src/memvid/mutation.rs
+++ b/src/memvid/mutation.rs
@@ -662,6 +662,84 @@ impl Memvid {
         Ok(())
     }
 
+    /// Shrink the embedded WAL region to `target_bytes` (rounded up to a
+    /// power of two, floored at [`WAL_SIZE_MEDIUM`]), reclaiming space a
+    /// bulk build reserved or grew into. The WAL region persists at its
+    /// high-water mark otherwise.
+    ///
+    /// Requires a fully-checkpointed WAL (call [`commit()`](Self::commit)
+    /// first); refuses otherwise, since pending records would be
+    /// destroyed. Everything after the WAL shifts DOWN — the exact mirror
+    /// of the growth path — and the file truncates.
+    pub fn shrink_wal_to(&mut self, target_bytes: u64) -> Result<()> {
+        self.ensure_writable()?;
+        // Pending records first: shrinking mid-ingest is a caller bug even
+        // when the target would make this a no-op.
+        if !self.wal.pending_records()?.is_empty() {
+            return Err(MemvidError::CheckpointFailed {
+                reason: "cannot shrink WAL with pending records — commit first".to_owned(),
+            });
+        }
+        let target = target_bytes.max(WAL_SIZE_MEDIUM).next_power_of_two();
+        if target >= self.header.wal_size {
+            return Ok(());
+        }
+
+        let delta = self.header.wal_size - target;
+        self.shift_data_for_wal_shrink(delta)?;
+        self.header.wal_size = target;
+        // The retained head still holds already-checkpointed record bytes
+        // from the larger region; a record straddling the new boundary
+        // would make the reopen scan below misparse them as corruption.
+        // Pending records are empty (checked above), so mark the region
+        // empty and reset the checkpoint position with it.
+        EmbeddedWal::write_empty_sentinel(&mut self.file, &self.header)?;
+        self.header.wal_checkpoint_pos = 0;
+        self.apply_wal_shrink_offsets(delta);
+
+        let catalog_end = self.catalog_data_end();
+        self.header.footer_offset = catalog_end
+            .max(self.header.footer_offset)
+            .max(self.data_end);
+
+        self.rewrite_toc_footer()?;
+        self.header.toc_checksum = self.toc.toc_checksum;
+        crate::persist_header(&mut self.file, &self.header)?;
+        self.file.sync_all()?;
+        self.wal = EmbeddedWal::open(&self.file, &self.header)?;
+        Ok(())
+    }
+
+    /// Move everything after the (shrinking) WAL region down by `delta`
+    /// and truncate. Copies front-to-back — with `dst < src` a forward
+    /// pass never reads bytes it has already overwritten.
+    fn shift_data_for_wal_shrink(&mut self, delta: u64) -> Result<()> {
+        if delta == 0 {
+            return Ok(());
+        }
+        let original_len = self.file.metadata()?.len();
+        let data_start = self.header.wal_offset + self.header.wal_size;
+        let total = original_len.saturating_sub(data_start);
+
+        let mut buffer = vec![0u8; WAL_SHIFT_BUFFER_SIZE];
+        let mut moved = 0u64;
+        while moved < total {
+            let chunk = min(total - moved, buffer.len() as u64);
+            let src = data_start + moved;
+            self.file.seek(SeekFrom::Start(src))?;
+            #[allow(clippy::cast_possible_truncation)]
+            self.file.read_exact(&mut buffer[..chunk as usize])?;
+            let dst = src - delta;
+            self.file.seek(SeekFrom::Start(dst))?;
+            #[allow(clippy::cast_possible_truncation)]
+            self.file.write_all(&buffer[..chunk as usize])?;
+            moved += chunk;
+        }
+
+        self.file.set_len(original_len - delta)?;
+        Ok(())
+    }
+
     fn apply_wal_growth_offsets(&mut self, delta: u64) {
         if delta == 0 {
             return;
@@ -680,81 +758,137 @@ impl Memvid {
         self.adjust_offsets_after_wal_growth(delta);
     }
 
-    fn adjust_offsets_after_wal_growth(&mut self, delta: u64) {
+    /// Exact mirror of [`Self::apply_wal_growth_offsets`]: every byte
+    /// past the WAL boundary moved LEFT by `delta`, so all bookkeeping
+    /// shifts down with it.
+    fn apply_wal_shrink_offsets(&mut self, delta: u64) {
         if delta == 0 {
             return;
         }
 
+        self.header.footer_offset = self.header.footer_offset.saturating_sub(delta);
+        self.data_end = self.data_end.saturating_sub(delta);
+        self.cached_payload_end = self.cached_payload_end.saturating_sub(delta);
+        self.adjust_offsets_after_wal_shrink(delta);
+    }
+
+    fn adjust_offsets_after_wal_growth(&mut self, delta: u64) {
+        if delta == 0 {
+            return;
+        }
+        self.map_data_offsets(|offset| offset + delta);
+    }
+
+    fn adjust_offsets_after_wal_shrink(&mut self, delta: u64) {
+        if delta == 0 {
+            return;
+        }
+        self.map_data_offsets(|offset| offset - delta);
+    }
+
+    /// Apply `f` to every stored non-zero data offset — frame payloads,
+    /// index manifests, the segment catalog, and lex storage. WAL growth
+    /// and shrink share this single walk so an offset class can never be
+    /// adjusted in one direction and forgotten in the other.
+    fn map_data_offsets(&mut self, f: impl Fn(u64) -> u64 + Copy) {
         for frame in &mut self.toc.frames {
             if frame.payload_offset != 0 {
-                frame.payload_offset += delta;
+                frame.payload_offset = f(frame.payload_offset);
             }
         }
 
         for segment in &mut self.toc.segments {
             if segment.bytes_offset != 0 {
-                segment.bytes_offset += delta;
+                segment.bytes_offset = f(segment.bytes_offset);
             }
         }
 
         if let Some(lex) = self.toc.indexes.lex.as_mut() {
             if lex.bytes_offset != 0 {
-                lex.bytes_offset += delta;
+                lex.bytes_offset = f(lex.bytes_offset);
             }
         }
         for manifest in &mut self.toc.indexes.lex_segments {
             if manifest.bytes_offset != 0 {
-                manifest.bytes_offset += delta;
+                manifest.bytes_offset = f(manifest.bytes_offset);
             }
         }
         if let Some(vec) = self.toc.indexes.vec.as_mut() {
             if vec.bytes_offset != 0 {
-                vec.bytes_offset += delta;
+                vec.bytes_offset = f(vec.bytes_offset);
+            }
+        }
+        if let Some(clip) = self.toc.indexes.clip.as_mut() {
+            if clip.bytes_offset != 0 {
+                clip.bytes_offset = f(clip.bytes_offset);
             }
         }
         if let Some(time_index) = self.toc.time_index.as_mut() {
             if time_index.bytes_offset != 0 {
-                time_index.bytes_offset += delta;
+                time_index.bytes_offset = f(time_index.bytes_offset);
             }
         }
         #[cfg(feature = "temporal_track")]
         if let Some(track) = self.toc.temporal_track.as_mut() {
             if track.bytes_offset != 0 {
-                track.bytes_offset += delta;
+                track.bytes_offset = f(track.bytes_offset);
+            }
+        }
+        // Post-commit tracks: growth only ever runs mid-batch (before these
+        // exist), but shrink runs after a full commit — miss one and its
+        // offset points past the truncated file.
+        if let Some(track) = self.toc.memories_track.as_mut() {
+            if track.bytes_offset != 0 {
+                track.bytes_offset = f(track.bytes_offset);
+            }
+        }
+        if let Some(mesh) = self.toc.logic_mesh.as_mut() {
+            if mesh.bytes_offset != 0 {
+                mesh.bytes_offset = f(mesh.bytes_offset);
+            }
+        }
+        if let Some(sketch) = self.toc.sketch_track.as_mut() {
+            if sketch.bytes_offset != 0 {
+                sketch.bytes_offset = f(sketch.bytes_offset);
             }
         }
 
         let catalog = &mut self.toc.segment_catalog;
         for descriptor in &mut catalog.lex_segments {
             if descriptor.common.bytes_offset != 0 {
-                descriptor.common.bytes_offset += delta;
+                descriptor.common.bytes_offset = f(descriptor.common.bytes_offset);
             }
         }
         for descriptor in &mut catalog.vec_segments {
             if descriptor.common.bytes_offset != 0 {
-                descriptor.common.bytes_offset += delta;
+                descriptor.common.bytes_offset = f(descriptor.common.bytes_offset);
             }
         }
         for descriptor in &mut catalog.time_segments {
             if descriptor.common.bytes_offset != 0 {
-                descriptor.common.bytes_offset += delta;
+                descriptor.common.bytes_offset = f(descriptor.common.bytes_offset);
             }
         }
         #[cfg(feature = "temporal_track")]
         for descriptor in &mut catalog.temporal_segments {
             if descriptor.common.bytes_offset != 0 {
-                descriptor.common.bytes_offset += delta;
+                descriptor.common.bytes_offset = f(descriptor.common.bytes_offset);
             }
         }
         for descriptor in &mut catalog.tantivy_segments {
             if descriptor.common.bytes_offset != 0 {
-                descriptor.common.bytes_offset += delta;
+                descriptor.common.bytes_offset = f(descriptor.common.bytes_offset);
+            }
+        }
+        for descriptor in &mut catalog.index_segments {
+            if descriptor.common.bytes_offset != 0 {
+                descriptor.common.bytes_offset = f(descriptor.common.bytes_offset);
             }
         }
 
         #[cfg(feature = "lex")]
         if let Ok(mut storage) = self.lex_storage.write() {
-            storage.adjust_offsets(delta);
+            storage.map_offsets(f);
         }
     }
     pub fn commit_with_options(&mut self, options: CommitOptions) -> Result<()> {

--- a/src/memvid/mutation.rs
+++ b/src/memvid/mutation.rs
@@ -1333,6 +1333,12 @@ impl Memvid {
                             data_cursor += payload_length;
                             // Keep cached_payload_end in sync (monotonically increasing)
                             self.cached_payload_end = self.cached_payload_end.max(data_cursor);
+                            // Advance data_end immediately: entries with no
+                            // search text are read back from the file later in
+                            // this same replay pass (frame_content for lex
+                            // indexing), and validate_frame_bounds rejects any
+                            // payload past data_end.
+                            self.data_end = self.data_end.max(data_cursor);
                             (
                                 payload_offset,
                                 payload_length,

--- a/src/memvid/mutation.rs
+++ b/src/memvid/mutation.rs
@@ -619,6 +619,11 @@ impl Memvid {
         crate::persist_header(&mut self.file, &self.header)?;
         self.file.sync_all()?;
         self.wal = EmbeddedWal::open(&self.file, &self.header)?;
+        // The reopen resets skip_sync; a mid-batch growth must keep the
+        // batch's fsync mode or every later append pays a full fsync.
+        if let Some(opts) = &self.batch_opts {
+            self.wal.set_skip_sync(opts.skip_sync);
+        }
         Ok(())
     }
 
@@ -2871,6 +2876,13 @@ impl Memvid {
         } else {
             self.tier().capacity_bytes()
         }
+    }
+
+    /// Snapshot of the embedded WAL's state (region size, pending
+    /// bytes, sequence, fsync mode).
+    #[must_use]
+    pub fn wal_stats(&self) -> crate::io::wal::WalStats {
+        self.wal.stats()
     }
 
     /// Get current storage capacity in bytes.

--- a/src/search/tantivy/storage.rs
+++ b/src/search/tantivy/storage.rs
@@ -138,13 +138,12 @@ impl EmbeddedLexStorage {
         (index_manifest, segments)
     }
 
-    pub fn adjust_offsets(&mut self, delta: u64) {
-        if delta == 0 {
-            return;
-        }
+    /// Apply `f` to every non-zero segment offset. Shared by WAL growth
+    /// (offsets shift up) and shrink (offsets shift down).
+    pub fn map_offsets(&mut self, f: impl Fn(u64) -> u64) {
         for segment in self.segments.values_mut() {
             if segment.bytes_offset != 0 {
-                segment.bytes_offset += delta;
+                segment.bytes_offset = f(segment.bytes_offset);
             }
         }
     }

--- a/tests/batch_replay_readback.rs
+++ b/tests/batch_replay_readback.rs
@@ -1,0 +1,59 @@
+//! Batch-mode commit replay must be able to read back frames it just
+//! wrote. A chunk entry whose text normalizes to nothing (the naive
+//! chunker emits a single-space chunk when a boundary lands on a space
+//! followed by a long whitespace-free run) carries no search text, so
+//! replay reads its payload back from the file for lex indexing.
+//! `data_end` used to advance only after the full replay loop, so that
+//! read tripped `validate_frame_bounds` with "payload extends past data
+//! region".
+
+use memvid_core::{Memvid, PutManyOpts, PutOptions};
+
+fn batch_opts() -> PutManyOpts {
+    PutManyOpts {
+        compression_level: 3,
+        disable_auto_checkpoint: true,
+        skip_sync: false,
+        enable_embedding: false,
+        auto_tag: false,
+        extract_dates: false,
+        no_raw: true,
+        enable_enrichment: false,
+        wal_pre_size_bytes: 0,
+    }
+}
+
+/// Chunk 1 ends after "Z." (sentence terminal just past the start), so
+/// chunk 2 begins on the space. The 4,000-char run that follows has no
+/// newline, sentence terminal, or whitespace, so the boundary search
+/// falls back to the backward whitespace scan and finds only the space
+/// at the chunk's own start, emitting a single-space chunk. Documents
+/// embedding large machine-generated blobs (escaped JSON, base64)
+/// produce this shape.
+fn degenerate_chunk_text() -> String {
+    let mut text = String::from("Z. ");
+    text.push_str(&"q".repeat(4_000));
+    text
+}
+
+#[test]
+fn batch_commit_replays_chunk_without_search_text() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("readback.mv2");
+
+    let mut mem = Memvid::create(&path).expect("create");
+    mem.enable_lex().expect("lex");
+    mem.begin_batch(batch_opts()).expect("batch");
+    let opts = PutOptions::builder()
+        .uri("mv2://test/degenerate")
+        .title("degenerate chunk doc")
+        .timestamp(1_700_000_000)
+        .extract_triplets(false)
+        .instant_index(false)
+        .build();
+    mem.put_bytes_with_options(degenerate_chunk_text().as_bytes(), opts)
+        .expect("put");
+    mem.end_batch().expect("end_batch");
+    mem.commit()
+        .expect("commit must replay a chunk whose text normalizes to nothing");
+}

--- a/tests/wal_growth.rs
+++ b/tests/wal_growth.rs
@@ -1,0 +1,72 @@
+//! Mid-batch WAL growth replaces the `EmbeddedWal` instance, which
+//! used to reset `skip_sync` to false — every append after the first
+//! doubling paid a full fsync, silently defeating the batch's deferred
+//! fsync mode. Growth must re-apply the batch options.
+
+use memvid_core::{Memvid, PutManyOpts, PutOptions};
+
+fn batch_opts() -> PutManyOpts {
+    PutManyOpts {
+        compression_level: 3,
+        disable_auto_checkpoint: true,
+        skip_sync: true,
+        enable_embedding: false,
+        auto_tag: false,
+        extract_dates: false,
+        no_raw: true,
+        enable_enrichment: false,
+        wal_pre_size_bytes: 0,
+    }
+}
+
+fn doc_text(i: usize) -> String {
+    let mut s = format!("zebra{i} quarterly report section ");
+    for w in 0..600 {
+        s.push_str(&format!("word{}x{} ", i, w));
+    }
+    s
+}
+
+fn put_doc(mem: &mut Memvid, i: usize) {
+    let opts = PutOptions::builder()
+        .uri(format!("mv2://growth/{i}"))
+        .title(format!("doc {i}"))
+        .timestamp(1_700_000_000 + i as i64)
+        .extract_triplets(false)
+        .instant_index(false)
+        .build();
+    mem.put_bytes_with_options(doc_text(i).as_bytes(), opts)
+        .expect("put");
+}
+
+#[test]
+fn growth_preserves_batch_skip_sync() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("growth.mv2");
+
+    let mut mem = Memvid::create(&path).expect("create");
+    mem.enable_lex().expect("lex");
+    mem.begin_batch(batch_opts()).expect("batch");
+    assert!(mem.wal_stats().skip_sync, "batch mode sets skip_sync");
+    let start_region = mem.wal_stats().region_size;
+
+    // ~6.6MB of docs against the default region forces mid-batch
+    // doubling — the growth path under test.
+    for i in 0..600 {
+        put_doc(&mut mem, i);
+    }
+    let stats = mem.wal_stats();
+    assert!(
+        stats.region_size > start_region,
+        "test requires mid-batch growth (region {} -> {})",
+        start_region,
+        stats.region_size
+    );
+    assert!(
+        stats.skip_sync,
+        "mid-batch growth must preserve the batch's skip_sync mode"
+    );
+
+    mem.end_batch().expect("end_batch");
+    mem.commit().expect("commit");
+}

--- a/tests/wal_shrink.rs
+++ b/tests/wal_shrink.rs
@@ -1,0 +1,183 @@
+//! `shrink_wal_to`: reclaim the WAL region a bulk build reserved or grew
+//! into. The region otherwise persists at its high-water mark forever —
+//! measured 14–45% dead space in production shards.
+
+use memvid_core::{Memvid, PutManyOpts, PutOptions, SearchRequest};
+
+fn batch_opts(pre_size: u64) -> PutManyOpts {
+    PutManyOpts {
+        compression_level: 3,
+        disable_auto_checkpoint: true,
+        skip_sync: false,
+        enable_embedding: false,
+        auto_tag: false,
+        extract_dates: false,
+        no_raw: true,
+        enable_enrichment: false,
+        wal_pre_size_bytes: pre_size,
+    }
+}
+
+fn doc_text(i: usize) -> String {
+    let mut s = format!("zebra{i} quarterly report section ");
+    for w in 0..600 {
+        s.push_str(&format!("word{}x{} ", i, w));
+    }
+    s
+}
+
+fn put_doc(mem: &mut Memvid, i: usize) {
+    let opts = PutOptions::builder()
+        .uri(format!("mv2://shrink/{i}"))
+        .title(format!("doc {i}"))
+        .timestamp(1_700_000_000 + i as i64)
+        .extract_triplets(false)
+        .instant_index(false)
+        .build();
+    mem.put_bytes_with_options(doc_text(i).as_bytes(), opts)
+        .expect("put");
+}
+
+#[test]
+fn shrink_reclaims_space_and_preserves_content() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("shrink.mv2");
+
+    let mut mem = Memvid::create(&path).expect("create");
+    mem.enable_lex().expect("lex");
+    // Pre-size generously (16 MiB, within the default capacity tier) —
+    // the exact situation a bulk build leaves behind.
+    mem.begin_batch(batch_opts(16 * 1024 * 1024))
+        .expect("batch");
+    for i in 0..200 {
+        put_doc(&mut mem, i);
+    }
+    mem.end_batch().expect("end_batch");
+    mem.commit().expect("commit");
+
+    let before = std::fs::metadata(&path).expect("meta").len();
+    mem.shrink_wal_to(0).expect("shrink");
+    let after = std::fs::metadata(&path).expect("meta").len();
+    assert!(
+        before - after > 8 * 1024 * 1024,
+        "shrink must reclaim most of the 16MiB region (before {before}, after {after})"
+    );
+    drop(mem);
+
+    let report = Memvid::verify(&path, true).expect("verify runs");
+    assert!(
+        !matches!(
+            report.overall_status,
+            memvid_core::VerificationStatus::Failed
+        ),
+        "deep verify must pass after shrink: {report:?}"
+    );
+
+    let mut mem = Memvid::open(&path).expect("reopen");
+    let hits = mem
+        .search(SearchRequest {
+            query: "zebra150".to_owned(),
+            top_k: 5,
+            snippet_chars: 80,
+            uri: None,
+            scope: None,
+            cursor: None,
+            #[cfg(feature = "temporal_track")]
+            temporal: None,
+            as_of_frame: None,
+            as_of_ts: None,
+            no_sketch: true,
+            acl_context: None,
+            acl_enforcement_mode: memvid_core::types::AclEnforcementMode::Audit,
+        })
+        .expect("search");
+    assert!(
+        !hits.hits.is_empty(),
+        "post-shrink search must find doc 150"
+    );
+    for i in [0usize, 99, 199] {
+        // Chunking means frame ids != doc order; resolve through the uri.
+        let frame = mem
+            .frame_by_uri(&format!("mv2://shrink/{i}"))
+            .expect("frame by uri");
+        let text = mem.frame_text_by_id(frame.id).expect("frame text readable");
+        assert!(
+            text.contains(&format!("zebra{i} ")),
+            "doc {i} text intact after shrink"
+        );
+    }
+
+    // Post-shrink appends must work (region regrows if needed).
+    mem.begin_batch(batch_opts(0)).expect("batch2");
+    for i in 200..220 {
+        put_doc(&mut mem, i);
+    }
+    mem.end_batch().expect("end_batch2");
+    mem.commit().expect("commit2");
+    let frame = mem
+        .frame_by_uri("mv2://shrink/219")
+        .expect("appended frame by uri");
+    let text = mem.frame_text_by_id(frame.id).expect("new frame");
+    assert!(text.contains("zebra219 "), "post-shrink append readable");
+}
+
+#[test]
+fn shrink_refuses_pending_wal_records() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("pending.mv2");
+    let mut mem = Memvid::create(&path).expect("create");
+    // Batch mode defers checkpointing — the record stays pending in the
+    // WAL until commit (a bare put would auto-checkpoint itself away).
+    mem.begin_batch(batch_opts(0)).expect("batch");
+    put_doc(&mut mem, 0);
+    mem.end_batch().expect("end_batch");
+    // No commit — a pending record must block the shrink.
+    let err = mem.shrink_wal_to(0);
+    assert!(err.is_err(), "shrink with pending WAL must refuse");
+}
+
+#[test]
+fn shrink_is_noop_at_or_below_floor() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("noop.mv2");
+    let mut mem = Memvid::create(&path).expect("create");
+    put_doc(&mut mem, 0);
+    mem.commit().expect("commit");
+    let before = std::fs::metadata(&path).expect("meta").len();
+    mem.shrink_wal_to(u64::MAX / 4).expect("noop shrink");
+    let after = std::fs::metadata(&path).expect("meta").len();
+    assert_eq!(before, after, "target above current size must be a no-op");
+}
+
+/// The retained head of a shrunk region still holds the old (already
+/// checkpointed) record bytes. With more than one region-floor's worth
+/// of records, one record straddles the new boundary and the post-shrink
+/// reopen scan misparsed it as "wal record length invalid". Shrink must
+/// leave the region reading as empty.
+#[test]
+fn shrink_survives_records_larger_than_target_region() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("straddle.mv2");
+
+    let mut mem = Memvid::create(&path).expect("create");
+    mem.enable_lex().expect("lex");
+    mem.begin_batch(batch_opts(16 * 1024 * 1024)).expect("batch");
+    // ~6.6MB of doc text (chunk entries roughly double it in the WAL) —
+    // comfortably past the 4MiB floor the region shrinks back to.
+    for i in 0..600 {
+        put_doc(&mut mem, i);
+    }
+    mem.end_batch().expect("end_batch");
+    mem.commit().expect("commit");
+
+    mem.shrink_wal_to(0)
+        .expect("shrink with >4MiB of stale records must succeed");
+    drop(mem);
+
+    let mut mem = Memvid::open(&path).expect("reopen after shrink");
+    let frame = mem
+        .frame_by_uri("mv2://shrink/599")
+        .expect("frame by uri");
+    let text = mem.frame_text_by_id(frame.id).expect("frame text");
+    assert!(text.contains("zebra599 "), "doc intact after shrink");
+}


### PR DESCRIPTION
These three commits came out of bulk-indexing a large corpus in batch mode. The build failed deterministically at the same frame on every attempt, at any WAL size.

## Replay read-back fails bounds validation

`apply_records` advances `data_end` after the full replay loop. A frame with no derivable search text forces `frame_content()` to read its payload back from the file during replay for lex indexing, and `validate_frame_bounds` rejects the just-written payload with `payload extends past data region`.

Search text is absent when a chunk's text normalizes to nothing. The naive chunker emits a single-space chunk when a boundary lands on a space followed by 1,200+ characters containing no whitespace or sentence terminal; documents embedding large machine-generated blobs (escaped JSON, base64) produce that shape.

The fix advances `data_end` per insert, mirroring `cached_payload_end`. `tests/batch_replay_readback.rs` reproduces the degenerate chunk through the public API ("Z. " followed by 4,000 characters with no whitespace).

## Mid-batch WAL growth resets skip_sync

`grow_wal_region` replaces the `EmbeddedWal` instance after resizing, and the fresh instance defaults to `skip_sync = false`. Every append after the first doubling pays a full fsync (F_FULLFSYNC on macOS); on a multi-gigabyte batch this dominates the build time.

The fix re-applies the batch's fsync mode after the reopen. `WalStats` gains a `skip_sync` field and `Memvid` gains a `wal_stats()` accessor so `tests/wal_growth.rs` can assert the mode survives growth.

## shrink_wal_to

A bulk build pre-sizes or doubles the WAL region to hold the whole batch, and the file carries that high-water mark afterward. `shrink_wal_to(target)` shifts everything after the WAL down and truncates, mirroring the growth path. It refuses to run while WAL records are pending.

Growth and shrink share one offset walk (`map_data_offsets`), so an offset class cannot be adjusted in one direction and missed in the other. The walk covers sections that only exist after a commit (memories, logic mesh, sketch, clip, parallel index segments); growth runs mid-batch before those exist, but shrink runs after a full commit.

The retained head of a shrunk region still holds checkpointed record bytes from the larger geometry, and a record straddling the new boundary makes the reopen scan report `wal record length invalid`. Shrink writes a zero sentinel at the region start and resets the checkpoint position.

`tests/wal_shrink.rs` covers reclaim, refusal on pending records, the no-op floor, and the straddling-record case. The full suite passes under default features and under `lex,temporal_track,parallel_segments`.
