### PR TITLE
feat: compile-time index size cap tiers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3152,7 +3152,7 @@ dependencies = [
 
 [[package]]
 name = "memvid-core"
-version = "2.0.135"
+version = "2.0.140"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,6 +133,17 @@ api_embed = ["dep:reqwest"]
 simd = ["dep:wide"]
 hnsw_bench = ["dep:hnsw", "dep:rand", "dep:space", "dep:rand_pcg"]
 
+# Compile-time index size caps. Baseline (no feature) is 512 MiB; enabling a
+# tier raises the cap. Cargo features are additive, so the largest enabled tier
+# wins — enabling several is safe, not a conflict.
+max_index_bytes_1gib = []
+max_index_bytes_2gib = []
+max_index_bytes_4gib = []
+# Same tiering for the chronological time index.
+max_time_index_bytes_1gib = []
+max_time_index_bytes_2gib = []
+max_time_index_bytes_4gib = []
+
 [dev-dependencies]
 fastrand = "2.0"
 tempfile = "3.10.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -337,8 +337,44 @@ use bincode::config::{self, Config};
 use io::header::HeaderCodec;
 
 const TIMELINE_PREVIEW_BYTES: usize = 120;
-const MAX_INDEX_BYTES: u64 = 512 * 1024 * 1024; // Increased from 64MB to 512MB for large datasets
-const MAX_TIME_INDEX_BYTES: u64 = 512 * 1024 * 1024;
+
+/// Maximum decoded size of the lex/vec/segment index, selected at compile time.
+///
+/// The baseline is 512 MiB. Enabling one of the `max_index_bytes_1gib`,
+/// `max_index_bytes_2gib`, or `max_index_bytes_4gib` Cargo features raises the
+/// cap. Cargo features are additive, so if more than one tier is enabled
+/// (e.g. via feature unification across the dependency graph) the largest wins.
+const MAX_INDEX_BYTES: u64 = {
+    const MIB: u64 = 1024 * 1024;
+    const GIB: u64 = 1024 * MIB;
+    if cfg!(feature = "max_index_bytes_4gib") {
+        4 * GIB
+    } else if cfg!(feature = "max_index_bytes_2gib") {
+        2 * GIB
+    } else if cfg!(feature = "max_index_bytes_1gib") {
+        GIB
+    } else {
+        512 * MIB
+    }
+};
+
+/// Maximum decoded size of the time index, selected at compile time.
+///
+/// Mirrors [`MAX_INDEX_BYTES`]: baseline 512 MiB, raised by the
+/// `max_time_index_bytes_1gib` / `_2gib` / `_4gib` features (largest wins).
+const MAX_TIME_INDEX_BYTES: u64 = {
+    const MIB: u64 = 1024 * 1024;
+    const GIB: u64 = 1024 * MIB;
+    if cfg!(feature = "max_time_index_bytes_4gib") {
+        4 * GIB
+    } else if cfg!(feature = "max_time_index_bytes_2gib") {
+        2 * GIB
+    } else if cfg!(feature = "max_time_index_bytes_1gib") {
+        GIB
+    } else {
+        512 * MIB
+    }
+};
 const MAX_FRAME_BYTES: u64 = 256 * 1024 * 1024;
 const DEFAULT_SEARCH_TEXT_LIMIT: usize = 32_768;
 


### PR DESCRIPTION
`MAX_INDEX_BYTES` and `MAX_TIME_INDEX_BYTES` are fixed at 512MiB. A large corpus hits the ceiling on open: past a few hundred thousand frames the serialized TOC alone can exceed the cap, and `Memvid::open` fails with `LimitExceeded` before any query runs.

This adds additive cargo features that raise each cap to 1, 2, or 4GiB (`max_index_bytes_1gib`, `_2gib`, `_4gib`, and the same tiers for the time index). Features are additive, so when feature unification enables several tiers the largest wins. The default stays 512MiB.

The caps bound decode allocations when opening a file, so raising a tier raises that bound for every file the build opens.
